### PR TITLE
Improve highlighting

### DIFF
--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -237,15 +237,11 @@
   }
   {
     'name': 'keyword.other.purescript'
-    'match': '\\b(derive|where|data|type|newtype)\\b'
+    'match': '\\b(derive|where|data|type|newtype|infix[lr]?)\\b'
   }
   {
     'name': 'storage.type.purescript'
     'match': '\\b(data|type|newtype)\\b'
-  }
-  {
-    'name': 'keyword.operator.purescript'
-    'match': '\\binfix[lr]?\\b'
   }
   {
     'name': 'keyword.control.purescript'

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -31,23 +31,6 @@
         'name': 'punctuation.definition.entity.purescript'
   }
   {
-    'begin': '(\\[)([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(\\|)'
-    'end': '(\\|)(\\])'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.definition.quasiquotes.begin.purescript'
-      '2':
-        'name': 'entity.name.tag.purescript'
-      '3':
-        'name': 'string.quoted.quasiquotes.purescript'
-    'endCaptures':
-      '1':
-        'name': 'string.quoted.quasiquotes.purescript'
-      '2':
-        'name': 'punctuation.definition.quasiquotes.end.purescript'
-    'contentName': 'string.quoted.quasiquotes.purescript'
-  }
-  {
     'name': 'meta.declaration.module.purescript'
     'begin': '\\b(module)\\b'
     'end': '(where)'
@@ -671,7 +654,7 @@
             'patterns': [
               {
                 'name': 'entity.name.type.purescript'
-                'match': '\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\b'
+                'match': '\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*'
               }
             ]
           '2':

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -644,21 +644,21 @@
     'patterns': [
       {
         'name': 'entity.name.type.purescript'
-        'match': '\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\b'
+        'match': '\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*'
       }
     ]
   'data_ctor':
     'patterns': [
       {
         'name': 'entity.name.tag.purescript'
-        'match': '\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\b'
+        'match': '\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*'
       }
     ]
   'generic_type':
     'patterns': [
       {
         'name': 'variable.other.generic-type.purescript'
-        'match': '\\b(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*\\b'
+        'match': '\\b(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*'
       }
     ]
   'class_constraint':

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -237,15 +237,15 @@
   }
   {
     'name': 'keyword.other.purescript'
-    'match': '\\b(derive|where|data|type|newtype|infix[lr]?)\\b'
+    'match': '\\b(derive|where|data|type|newtype|infix[lr]?)(?!\')\\b'
   }
   {
     'name': 'storage.type.purescript'
-    'match': '\\b(data|type|newtype)\\b'
+    'match': '\\b(data|type|newtype)(?!\')\\b'
   }
   {
     'name': 'keyword.control.purescript'
-    'match': '\\b(do|if|then|else|case|of|let|in)\\b'
+    'match': '\\b(do|if|then|else|case|of|let|in)(?!\')\\b'
   }
   {
     'name': 'constant.numeric.float.purescript'

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -117,7 +117,7 @@
   {
     'name': 'meta.import.purescript'
     'begin': '\\b(import)\\b'
-    'end': '($|;|(?=--))'
+    'end': '($|(?=--))'
     'beginCaptures':
       '1':
         'name': 'keyword.other.purescript'

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -129,7 +129,7 @@
         'include': '#module_exports'
       }
       {
-        'match': '\\b(qualified|as|hiding)\\b'
+        'match': '\\b(as|hiding)\\b'
         'captures':
           '1':
             'name': 'keyword.other.purescript'

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -396,7 +396,7 @@
       }
       {
         'name': 'comment.block.purescript'
-        'begin': '\\{-(?!#)'
+        'begin': '\\{-'
         'end': '-\\}'
         'applyEndPatternLast': 1
         'beginCaptures':

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -489,20 +489,20 @@ purescriptGrammar =
       ]
     type_name:
       name: 'entity.name.type'
-      match: /\b{className}\b/
+      match: /\b{className}/
     data_ctor:
       name: 'entity.name.tag'
-      match: /\b{className}\b/
+      match: /\b{className}/
     generic_type:
       name: 'variable.other.generic-type'
-      match: /\b{functionName}\b/
+      match: /\b{functionName}/
     class_constraint:
       name: 'meta.class-constraint'
       match: /{classConstraint}/
       captures:
         1: patterns: [
           name: 'entity.name.type'
-          match: /\b{className}\b/
+          match: /\b{className}/
         ]
         2: patterns: [
             include: '#type_name'

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -149,7 +149,7 @@ purescriptGrammar =
     ,
       name: 'meta.import'
       begin: /\b(import)\b/
-      end: /($|;|(?=--))/
+      end: /($|(?=--))/
       beginCaptures:
         1: name: 'keyword.other'
       patterns: [

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -157,7 +157,7 @@ purescriptGrammar =
         ,
           include: '#module_exports'
         ,
-          match: /\b(qualified|as|hiding)\b/
+          match: /\b(as|hiding)\b/
           captures:
             1: name: 'keyword.other'
       ]

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -88,17 +88,6 @@ purescriptGrammar =
       to be rewritten as an infix expression (4 `elem` [1..10]).
       ###
     ,
-      begin: /(\[)({functionNameOne})(\|)/
-      end: /(\|)(\])/
-      beginCaptures:
-        1: name: 'punctuation.definition.quasiquotes.begin'
-        2: name: 'entity.name.tag'
-        3: name: 'string.quoted.quasiquotes'
-      endCaptures:
-        1: name: 'string.quoted.quasiquotes'
-        2: name: 'punctuation.definition.quasiquotes.end'
-      contentName: 'string.quoted.quasiquotes'
-    ,
       name: 'meta.declaration.module'
       begin: /\b(module)\b/
       end: /(where)/

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -327,7 +327,7 @@ purescriptGrammar =
           ]
         ,
           name: 'comment.block'
-          begin: /\{-(?!#)/
+          begin: /\{-/
           end: /-\}/
           applyEndPatternLast: 1
           beginCaptures:

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -223,13 +223,13 @@ purescriptGrammar =
       ]
     ,
       name: 'keyword.other'
-      match: /\b(derive|where|data|type|newtype|infix[lr]?)\b/
+      match: /\b(derive|where|data|type|newtype|infix[lr]?)(?!')\b/
     ,
       name: 'storage.type'
-      match: /\b(data|type|newtype)\b/
+      match: /\b(data|type|newtype)(?!')\b/
     ,
       name: 'keyword.control'
-      match: /\b(do|if|then|else|case|of|let|in)\b/
+      match: /\b(do|if|then|else|case|of|let|in)(?!')\b/
     ,
       name: 'constant.numeric.float'
       match: /\b([0-9]+\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\b/

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -223,13 +223,10 @@ purescriptGrammar =
       ]
     ,
       name: 'keyword.other'
-      match: /\b(derive|where|data|type|newtype)\b/
+      match: /\b(derive|where|data|type|newtype|infix[lr]?)\b/
     ,
       name: 'storage.type'
       match: /\b(data|type|newtype)\b/
-    ,
-      name: 'keyword.operator'
-      match: /\binfix[lr]?\b/
     ,
       name: 'keyword.control'
       match: /\b(do|if|then|else|case|of|let|in)\b/


### PR DESCRIPTION
* Remove `\b` from patterns that end with apostrophes; fixes #17
* Remove quasiquotes from grammar
* Imports can't end in semicolons
* `qualified` is no longer a keyword
* Move `infix[lr]?` to `keyword.other`
* Remove syntax for pragmas
* Don't highlight keywords if followed by an apostrophe 
