### PR TITLE
Improve highlighting

### DIFF
--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -237,7 +237,7 @@
   }
   {
     'name': 'keyword.other.purescript'
-    'match': '\\b(derive|where|data|type|newtype|infix[lr]?)(?!\')\\b'
+    'match': '\\b(derive|where|data|type|newtype|infix[lr]?|foreign)(?!\')\\b'
   }
   {
     'name': 'storage.type.purescript'

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -569,7 +569,7 @@
     'patterns': [
       {
         'name': 'meta.class-constraints.purescript'
-        'match': '(?:(?:\\()(?:(?<classConstraints>(?:(?:(?:([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*)\\s+)(?:(?<classConstraint>(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*|(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:\\s+)\\s*\\g<classConstraint>)?))))(?:\\s*(?:,)\\s*\\g<classConstraints>)?))(?:\\))(?:\\s*(=>|<=|⇒)))'
+        'match': '(?:(?:\\()(?:(?<classConstraints>(?:(?:(?:([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*)\\s+)(?:(?<classConstraint>(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*|(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:\\s+)\\s*\\g<classConstraint>)?))))(?:\\s*(?:,)\\s*\\g<classConstraints>)?))(?:\\))(?:\\s*(=>|<=|⇐|⇒)))'
         'captures':
           '1':
             'patterns': [
@@ -582,7 +582,7 @@
       }
       {
         'name': 'meta.class-constraints.purescript'
-        'match': '((?:(?:([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*)\\s+)(?:(?<classConstraint>(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*|(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:\\s+)\\s*\\g<classConstraint>)?))))\\s*(=>|<=|⇒)'
+        'match': '((?:(?:([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*)\\s+)(?:(?<classConstraint>(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*|(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:\\s+)\\s*\\g<classConstraint>)?))))\\s*(=>|<=|⇐|⇒)'
         'captures':
           '1':
             'patterns': [
@@ -603,11 +603,11 @@
       }
       {
         'name': 'keyword.other.big-arrow-left.purescript'
-        'match': '<='
+        'match': '<=|⇐'
       }
       {
         'name': 'keyword.other.forall.purescript'
-        'match': 'forall'
+        'match': 'forall|∀'
       }
       {
         'include': '#generic_type'

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -223,7 +223,7 @@ purescriptGrammar =
       ]
     ,
       name: 'keyword.other'
-      match: /\b(derive|where|data|type|newtype|infix[lr]?)(?!')\b/
+      match: /\b(derive|where|data|type|newtype|infix[lr]?|foreign)(?!')\b/
     ,
       name: 'storage.type'
       match: /\b(data|type|newtype)(?!')\b/

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -442,14 +442,14 @@ purescriptGrammar =
           name: 'meta.class-constraints'
           match: concat /\(/,
             list('classConstraints',/{classConstraint}/,/,/),
-            /\)/, /\s*(=>|<=|⇒)/
+            /\)/, /\s*(=>|<=|⇐|⇒)/
           captures:
             1: patterns: [{include: '#class_constraint'}]
             #2,3 are from classConstraint
             4: name: 'keyword.other.big-arrow'
         ,
           name: 'meta.class-constraints'
-          match: /({classConstraint})\s*(=>|<=|⇒)/
+          match: /({classConstraint})\s*(=>|<=|⇐|⇒)/
           captures:
             1: patterns: [{include: '#class_constraint'}]
             #2,3 are from classConstraint
@@ -462,10 +462,10 @@ purescriptGrammar =
           match: /=>|⇒/
         ,
           name: 'keyword.other.big-arrow-left'
-          match: /<=/
+          match: /<=|⇐/
         ,
           name: 'keyword.other.forall'
-          match: /forall/
+          match: /forall|∀/
         ,
           include: '#generic_type'
         ,


### PR DESCRIPTION
- Add `forall` symbol and fat left arrow as keywords. Fixes #20
- Always highlight `foreign` as it is a fully reserved word.