### PR TITLE
Highlight boolean constants. Fix #14.

### DIFF
--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -252,6 +252,10 @@
     'match': '\\b([0-9]+\\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\\b'
   }
   {
+    'name': 'constant.language.boolean.purescript'
+    'match': '\\b(true|false)\\b'
+  }
+  {
     'name': 'constant.numeric.purescript'
     'match': '\\b([0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\\b'
   }

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -235,6 +235,9 @@ purescriptGrammar =
       match: /\b([0-9]+\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\b/
       # Floats are always decimal
     ,
+      name: 'constant.language.boolean'
+      match: /\b(true|false)\b/
+    ,
       name: 'constant.numeric'
       match: /\b([0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\b/
     ,


### PR DESCRIPTION
Per the linked issue #14 - `True` / `False` are already not special, they are just highlighted as types / data constructors.