### PR TITLE
Set autoIndentOnPaste to false

### DIFF
--- a/settings/language-purescript.cson
+++ b/settings/language-purescript.cson
@@ -1,3 +1,4 @@
 '.source.purescript':
   'editor':
+    'autoIndentOnPaste': false
     'commentStart': '-- '


### PR DESCRIPTION
Auto-indent on paste seems to get indentation wrong most of the time. It seems to be set to false in several white-space-significant language plug-ins, including language-python, language-coffee-script and language-elm. (Though I added it to the last one.)

Here's an example of when it gets in the way:

```purescript
module MyModule
  ( myExport
  ) where
```

Let's say now I want to paste a list of imports from another module, they'll all be indented two spaces.

Another example (not very imaginative, granted):

```purescript
myFirstFunction = doSomething

mySecondFunction = do
   something
   somethingElse
```

If I re-order the functions by cutting and pasting, `myFirstFunction` will be indented two spaces.