### PR TITLE
Remove Haskell definitions

### DIFF
--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -382,16 +382,16 @@
   'block_comment':
     'patterns': [
       {
-        'name': 'comment.block.haddock.purescript'
+        'name': 'comment.block.documentation.purescript'
         'begin': '\\{-\\s*\\|'
         'end': '-\\}'
         'applyEndPatternLast': 1
         'beginCaptures':
           '0':
-            'name': 'punctuation.definition.comment.haddock.purescript'
+            'name': 'punctuation.definition.comment.documentation.purescript'
         'endCaptures':
           '0':
-            'name': 'punctuation.definition.comment.haddock.purescript'
+            'name': 'punctuation.definition.comment.documentation.purescript'
         'patterns': [
           {
             'include': '#block_comment'
@@ -423,14 +423,14 @@
             'name': 'punctuation.whitespace.comment.leading.purescript'
         'patterns': [
           {
-            'name': 'comment.line.double-dash.haddock.purescript'
+            'name': 'comment.line.double-dash.documentation.purescript'
             'begin': '(--+)\\s+(\\|)'
             'end': '\\n'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.purescript'
               '2':
-                'name': 'punctuation.definition.comment.haddock.purescript'
+                'name': 'punctuation.definition.comment.documentation.purescript'
           }
         ]
       }

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -383,7 +383,7 @@
     'patterns': [
       {
         'name': 'comment.block.haddock.purescript'
-        'begin': '\\{-\\s*[|^]'
+        'begin': '\\{-\\s*\\|'
         'end': '-\\}'
         'applyEndPatternLast': 1
         'beginCaptures':
@@ -416,7 +416,7 @@
   'comments':
     'patterns': [
       {
-        'begin': '(^[ \\t]+)?(?=--+\\s+[|^])'
+        'begin': '(^[ \\t]+)?(?=--+\\s+\\|)'
         'end': '(?!\\G)'
         'beginCaptures':
           '1':
@@ -424,7 +424,7 @@
         'patterns': [
           {
             'name': 'comment.line.double-dash.haddock.purescript'
-            'begin': '(--+)\\s+([|^])'
+            'begin': '(--+)\\s+(\\|)'
             'end': '\\n'
             'beginCaptures':
               '1':

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -529,9 +529,6 @@
                 'name': 'entity.name.function.purescript'
                 'match': '(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*'
               }
-              {
-                'include': '#infix_op'
-              }
             ]
           '3':
             'name': 'keyword.other.double-colon.purescript'
@@ -555,9 +552,6 @@
               {
                 'name': 'entity.other.attribute-name.purescript'
                 'match': '(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*'
-              }
-              {
-                'include': '#infix_op'
               }
             ]
           '2':

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -13,7 +13,7 @@
   'operatorFun': '(?:\\((?!--+\\))[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_"\']]+\\))'
   'character': '(?:[ -\\[\\]-~]|(\\\\(?:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\"\'\\&]))|(\\\\o[0-7]+)|(\\\\x[0-9A-Fa-f]+)|(\\^[A-Z@\\[\\]\\\\\\^_]))'
   'classConstraint': '(?:(?:([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*)\\s+)(?:(?<classConstraint>(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*|(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:\\s+)\\s*\\g<classConstraint>)?)))'
-  'functionTypeDeclaration': '(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*|(?:\\((?!--+\\))[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_"\']]+\\)))(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))'
+  'functionTypeDeclaration': '(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))'
   'ctorArgs': '(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*|(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*|(?:(?:[\\w()\'→⇒\\[\\],]|->|=>)+\\s*)+)'
   'ctor': '(?:(?:\\b([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*)\\s+)(?:(?<ctorArgs>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*|(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*|(?:(?:[\\w()\'→⇒\\[\\],]|->|=>)+\\s*)+))(?:\\s*(?:\\s+)\\s*\\g<ctorArgs>)?)?))'
   'typeDecl': '.+?'
@@ -91,7 +91,7 @@
   }
   {
     'name': 'meta.foreign.purescript'
-    'begin': '^(\\s*)(foreign)\\s+(import)\\s+(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*|(?:\\((?!--+\\))[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_"\']]+\\)))(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))?'
+    'begin': '^(\\s*)(foreign)\\s+(import)\\s+(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))?'
     'end': '^(?!\\1[ \\t]|[ \\t]*$)'
     'contentName': 'meta.type-signature.purescript'
     'beginCaptures':
@@ -519,7 +519,7 @@
     'patterns': [
       {
         'name': 'meta.function.type-declaration.purescript'
-        'begin': '(?:(?:^(\\s*))(?:(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*|(?:\\((?!--+\\))[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_"\']]+\\)))(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ ))))(?:(?!.*<-)))'
+        'begin': '(?:(?:^(\\s*))(?:(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ ))))(?:(?!.*<-)))'
         'end': '^(?!\\1[ \\t]|[ \\t]*$)'
         'contentName': 'meta.type-signature.purescript'
         'beginCaptures':
@@ -546,8 +546,8 @@
     'patterns': [
       {
         'name': 'meta.record-field.type-declaration.purescript'
-        'begin': '(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*|(?:\\((?!--+\\))[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_"\']]+\\)))(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))'
-        'end': '(?=(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*|(?:\\((?!--+\\))[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_"\']]+\\)))(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))|})'
+        'begin': '(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))'
+        'end': '(?=(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))|})'
         'contentName': 'meta.type-signature.purescript'
         'beginCaptures':
           '1':

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -33,7 +33,7 @@ purescriptGrammar =
     className: /{classNameOne}(?:\.{classNameOne})*/
     operatorChar: /[\p{S}\p{P}&&[^(),;\[\]`{}_"']]/
     ###
-    In case this regex seems overly general, note that Haskell
+    In case this regex seems overly general, note that PureScript
     permits the definition of new operators which can be nearly any string
     of punctuation characters, such as $%^&*.
     ###
@@ -84,8 +84,8 @@ purescriptGrammar =
         2: name: 'punctuation.definition.entity'
       ###
       In case this regex seems unusual for an infix operator, note
-      that Haskell allows any ordinary function application (elem 4 [1..10])
-      to be rewritten as an infix expression (4 `elem` [1..10]).
+      that PureScript allows any ordinary function application (elem 4 (1..10))
+      to be rewritten as an infix expression (4 `elem` (1..10)).
       ###
     ,
       name: 'meta.declaration.module'

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -416,8 +416,6 @@ purescriptGrammar =
           patterns: [
               name: 'entity.name.function'
               match: /{functionName}/
-            ,
-              include: '#infix_op'
           ]
         3: name: 'keyword.other.double-colon'
       patterns: [
@@ -433,8 +431,6 @@ purescriptGrammar =
           patterns: [
               name: 'entity.other.attribute-name'
               match: /{functionName}/
-            ,
-              include: '#infix_op'
           ]
         2: name: 'keyword.other.double-colon'
       patterns: [

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -318,7 +318,7 @@ purescriptGrammar =
     block_comment:
       patterns: [
           name: 'comment.block.haddock'
-          begin: /\{-\s*[|^]/
+          begin: /\{-\s*\|/
           end: /-\}/
           applyEndPatternLast: 1
           beginCaptures:
@@ -341,13 +341,13 @@ purescriptGrammar =
       ]
     comments:
       patterns: [
-          begin: /({maybeBirdTrack}[ \t]+)?(?=--+\s+[|^])/
+          begin: /({maybeBirdTrack}[ \t]+)?(?=--+\s+\|)/
           end: /(?!\G)/
           beginCaptures:
             1: name: 'punctuation.whitespace.comment.leading'
           patterns: [
               name: 'comment.line.double-dash.haddock'
-              begin: /(--+)\s+([|^])/
+              begin: /(--+)\s+(\|)/
               end: /\n/
               beginCaptures:
                 1: name: 'punctuation.definition.comment'

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -317,14 +317,14 @@ purescriptGrammar =
   repository:
     block_comment:
       patterns: [
-          name: 'comment.block.haddock'
+          name: 'comment.block.documentation'
           begin: /\{-\s*\|/
           end: /-\}/
           applyEndPatternLast: 1
           beginCaptures:
-            0: name: 'punctuation.definition.comment.haddock'
+            0: name: 'punctuation.definition.comment.documentation'
           endCaptures:
-            0: name: 'punctuation.definition.comment.haddock'
+            0: name: 'punctuation.definition.comment.documentation'
           patterns: [
               include: '#block_comment'
           ]
@@ -346,12 +346,12 @@ purescriptGrammar =
           beginCaptures:
             1: name: 'punctuation.whitespace.comment.leading'
           patterns: [
-              name: 'comment.line.double-dash.haddock'
+              name: 'comment.line.double-dash.documentation'
               begin: /(--+)\s+(\|)/
               end: /\n/
               beginCaptures:
                 1: name: 'punctuation.definition.comment'
-                2: name: 'punctuation.definition.comment.haddock'
+                2: name: 'punctuation.definition.comment.documentation'
           ]
         ,
           ###

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -60,7 +60,7 @@ purescriptGrammar =
     classConstraint: concat /({className})\s+/,
       list('classConstraint',/{className}|{functionName}/,/\s+/)
     functionTypeDeclaration:
-      concat list('functionTypeDeclaration',/{functionName}|{operatorFun}/,/,/),
+      concat list('functionTypeDeclaration',/{functionName}/,/,/),
         /\s*(::|∷ )/
     ctorArgs: ///
       (?:


### PR DESCRIPTION
This PR removes references to Haskell and Haddock, removes unsupported Haddock documentation styles, and removes symbolic operators from places they aren't actually supported.