### PR TITLE
Highlight function types when split across lines

### DIFF
--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -13,7 +13,7 @@
   'operatorFun': '(?:\\((?!--+\\))[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_"\']]+\\))'
   'character': '(?:[ -\\[\\]-~]|(\\\\(?:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\"\'\\&]))|(\\\\o[0-7]+)|(\\\\x[0-9A-Fa-f]+)|(\\^[A-Z@\\[\\]\\\\\\^_]))'
   'classConstraint': '(?:(?:([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*)\\s+)(?:(?<classConstraint>(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*|(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:\\s+)\\s*\\g<classConstraint>)?)))'
-  'functionTypeDeclaration': '(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))'
+  'functionTypeDeclaration': '([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)\\s*(::|∷)'
   'ctorArgs': '(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*|(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*|(?:(?:[\\w()\'→⇒\\[\\],]|->|=>)+\\s*)+)'
   'ctor': '(?:(?:\\b([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*)\\s+)(?:(?<ctorArgs>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*|(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*|(?:(?:[\\w()\'→⇒\\[\\],]|->|=>)+\\s*)+))(?:\\s*(?:\\s+)\\s*\\g<ctorArgs>)?)?))'
   'typeDecl': '.+?'
@@ -91,7 +91,7 @@
   }
   {
     'name': 'meta.foreign.data.purescript'
-    'begin': '^(\\s*)(foreign)\\s+(import)\\s+(data)\\s+([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)\\s*(::|∷)'
+    'begin': '^(\\s*)(foreign)\\s+(import)\\s+(data)\\s+([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)'
     'end': '^(?!\\1[ \\t]|[ \\t]*$)'
     'contentName': 'meta.kind-signature.purescript'
     'beginCaptures':
@@ -107,13 +107,16 @@
         'name': 'keyword.other.double-colon.purescript'
     'patterns': [
       {
+        'include': '#double_colon'
+      }
+      {
         'include': '#kind_signature'
       }
     ]
   }
   {
     'name': 'meta.foreign.purescript'
-    'begin': '^(\\s*)(foreign)\\s+(import)\\s+(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))?'
+    'begin': '^(\\s*)(foreign)\\s+(import)\\s+([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)'
     'end': '^(?!\\1[ \\t]|[ \\t]*$)'
     'contentName': 'meta.type-signature.purescript'
     'beginCaptures':
@@ -122,15 +125,11 @@
       '3':
         'name': 'keyword.other.purescript'
       '4':
-        'patterns': [
-          {
-            'name': 'entity.name.function.purescript'
-            'match': '(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*'
-          }
-        ]
-      '5':
-        'name': 'keyword.other.double-colon.purescript'
+        'name': 'entity.name.function.purescript'
     'patterns': [
+      {
+        'include': '#double_colon'
+      }
       {
         'include': '#type_signature'
       }
@@ -366,19 +365,6 @@
         ]
   }
   {
-    'match': '(::|∷)((?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*|(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*|\\->|=>|[→⇒()\\[\\]]|\\s)*)'
-    'captures':
-      '1':
-        'name': 'keyword.other.double-colon.purescript'
-      '2':
-        'name': 'meta.type-signature.purescript'
-        'patterns': [
-          {
-            'include': '#type_signature'
-          }
-        ]
-  }
-  {
     'include': '#data_ctor'
   }
   {
@@ -541,20 +527,18 @@
     'patterns': [
       {
         'name': 'meta.function.type-declaration.purescript'
-        'begin': '(?:(?:^(\\s*))(?:(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ ))))(?:(?!.*<-)))'
+        'begin': '^(\\s*)([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)\\s*(?:(::|∷)(?!.*<-)|$)'
         'end': '^(?!\\1[ \\t]|[ \\t]*$)'
         'contentName': 'meta.type-signature.purescript'
         'beginCaptures':
           '2':
-            'patterns': [
-              {
-                'name': 'entity.name.function.purescript'
-                'match': '(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*'
-              }
-            ]
+            'name': 'entity.name.function.purescript'
           '3':
             'name': 'keyword.other.double-colon.purescript'
         'patterns': [
+          {
+            'include': '#double_colon'
+          }
           {
             'include': '#type_signature'
           }
@@ -565,8 +549,8 @@
     'patterns': [
       {
         'name': 'meta.record-field.type-declaration.purescript'
-        'begin': '(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))'
-        'end': '(?=(?:(?:(?<functionTypeDeclaration>(?:(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)(?:\\s*(?:,)\\s*\\g<functionTypeDeclaration>)?))(?:\\s*(::|∷ )))|})'
+        'begin': '([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)\\s*(::|∷)'
+        'end': '(?=([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)\\s*(::|∷)|})'
         'contentName': 'meta.type-signature.purescript'
         'beginCaptures':
           '1':
@@ -677,6 +661,13 @@
       {
         'name': 'variable.other.generic-type.purescript'
         'match': '\\b(?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*(?:\\.[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)*\\.)?[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*'
+      }
+    ]
+  'double_colon':
+    'patterns': [
+      {
+        'name': 'keyword.other.double-colon.purescript'
+        'match': '(?:::|∷)'
       }
     ]
   'class_constraint':

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -365,6 +365,18 @@
         ]
   }
   {
+    'begin': '^(\\s*)(?:(::|∷))'
+    'beginCaptures':
+      '2':
+        'name': 'keyword.other.double-colon.purescript'
+    'end': '^(?!\\1[ \\t]*|[ \\t]*$)'
+    'patterns': [
+      {
+        'include': '#type_signature'
+      }
+    ]
+  }
+  {
     'include': '#data_ctor'
   }
   {
@@ -527,7 +539,7 @@
     'patterns': [
       {
         'name': 'meta.function.type-declaration.purescript'
-        'begin': '^(\\s*)([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)\\s*(?:(::|∷)(?!.*<-)|$)'
+        'begin': '^(\\s*)([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\']*)\\s*(?:(::|∷)(?!.*<-))'
         'end': '^(?!\\1[ \\t]|[ \\t]*$)'
         'contentName': 'meta.type-signature.purescript'
         'beginCaptures':

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -60,8 +60,7 @@ purescriptGrammar =
     classConstraint: concat /({className})\s+/,
       list('classConstraint',/{className}|{functionName}/,/\s+/)
     functionTypeDeclaration:
-      concat list('functionTypeDeclaration',/{functionName}/,/,/),
-        /\s*(::|∷ )/
+      /({functionNameOne})\s*(::|∷)/
     ctorArgs: ///
       (?:
       {className}     #proper type
@@ -130,7 +129,7 @@ purescriptGrammar =
       ]
     ,
       name: 'meta.foreign.data'
-      begin: /^(\s*)(foreign)\s+(import)\s+(data)\s+({classNameOne})\s*(::|∷)/
+      begin: /^(\s*)(foreign)\s+(import)\s+(data)\s+({classNameOne})/
       end: /{indentBlockEnd}/
       contentName: 'meta.kind-signature'
       beginCaptures:
@@ -139,25 +138,23 @@ purescriptGrammar =
         4: name: 'keyword.other'
         5: name: 'entity.name.type'
         6: name: 'keyword.other.double-colon'
-      patterns:[
+      patterns: [
+          include: '#double_colon'
+        ,
           include: '#kind_signature'
       ]
     ,
       name: 'meta.foreign'
-      # functionTypeDeclaration so it can be wrapped to the next line without losing most highlighting
-      begin: /^(\s*)(foreign)\s+(import)\s+{functionTypeDeclaration}?/
+      begin: /^(\s*)(foreign)\s+(import)\s+({functionNameOne})/
       end: /{indentBlockEnd}/
       contentName: 'meta.type-signature'
       beginCaptures:
         2: name: 'keyword.other'
         3: name: 'keyword.other'
-        4:
-          patterns: [
-              name: 'entity.name.function'
-              match: /{functionName}/
-          ]
-        5: name: 'keyword.other.double-colon'
-      patterns:[
+        4: name: 'entity.name.function'
+      patterns: [
+          include: '#double_colon'
+        ,
           include: '#type_signature'
       ]
     ,
@@ -308,11 +305,6 @@ purescriptGrammar =
         2: name: 'keyword.other.double-colon'
         3: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
     ,
-      match: '(::|∷)((?:{className}|{functionName}|\\->|=>|[→⇒()\\[\\]]|\\s)*)'
-      captures:
-        1: name: 'keyword.other.double-colon'
-        2: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
-    ,
       include: '#data_ctor'
     ,
       include: '#comments'
@@ -422,17 +414,15 @@ purescriptGrammar =
       match: /(?:{className}\.)*{className}\.?/
     function_type_declaration:
       name: 'meta.function.type-declaration'
-      begin: concat /{maybeBirdTrack}(\s*)/,/{functionTypeDeclaration}/,/(?!.*<-)/
+      begin: /^(\s*)({functionNameOne})\s*(?:(::|∷)(?!.*<-)|$)/
       end: /{indentBlockEnd}/
       contentName: 'meta.type-signature'
       beginCaptures:
-        2:
-          patterns: [
-              name: 'entity.name.function'
-              match: /{functionName}/
-          ]
+        2: name: 'entity.name.function'
         3: name: 'keyword.other.double-colon'
       patterns: [
+          include: '#double_colon'
+        ,
           include: '#type_signature'
       ]
     record_field_declaration:
@@ -509,6 +499,9 @@ purescriptGrammar =
     generic_type:
       name: 'variable.other.generic-type'
       match: /\b{functionName}/
+    double_colon:
+      name: 'keyword.other.double-colon'
+      match: ///(?: :: | ∷ )///
     class_constraint:
       name: 'meta.class-constraint'
       match: /{classConstraint}/

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -305,6 +305,21 @@ purescriptGrammar =
         2: name: 'keyword.other.double-colon'
         3: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
     ,
+      begin: ///
+        ^
+        ( \s* )
+        (?: ( :: | ∷ ) )
+        ///
+      beginCaptures:
+        2: name: 'keyword.other.double-colon'
+      end: ///
+        ^
+        (?! \1 {indentChar}* | {indentChar}* $ )
+        ///
+      patterns: [
+          include: '#type_signature'
+      ]
+    ,
       include: '#data_ctor'
     ,
       include: '#comments'
@@ -414,7 +429,13 @@ purescriptGrammar =
       match: /(?:{className}\.)*{className}\.?/
     function_type_declaration:
       name: 'meta.function.type-declaration'
-      begin: /^(\s*)({functionNameOne})\s*(?:(::|∷)(?!.*<-)|$)/
+      begin: ///
+        ^
+        ( \s* )
+        ( {functionNameOne} )
+        \s*
+        (?: ( :: | ∷ ) (?! .* <- ) )
+        ///
       end: /{indentBlockEnd}/
       contentName: 'meta.type-signature'
       beginCaptures:


### PR DESCRIPTION
This addresses #22, but only for `foreign` declarations.

Additionally, this removes the unsupported Haskell syntax:

```haskell
foo, bar :: Baz
```