### PR TITLE
Fix typo on declaration

### DIFF
--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -205,7 +205,7 @@
             'name': 'punctuation.separator.pipe.purescript'
       }
       {
-        'name': 'meta.declaratyion.type.data.record.block.purescript'
+        'name': 'meta.declaration.type.data.record.block.purescript'
         'begin': '\\{'
         'beginCaptures':
           '0':


### PR DESCRIPTION
I just saw that this file was used by the VS Code purescript-language extension for the grammar.
Maybe this will fix the [issue ](https://github.com/purescript-contrib/atom-language-purescript/issues/25) with record highlighting ?

![image](https://cloud.githubusercontent.com/assets/1443499/24201145/8167a7e0-0f0f-11e7-840a-e3cef50249d7.png)
