### PR TITLE
add `ado` keyword for applicative do notation

### DIFF
--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -256,7 +256,7 @@
   }
   {
     'name': 'keyword.control.purescript'
-    'match': '\\b(do|if|then|else|case|of|let|in)(?!\')\\b'
+    'match': '\\b(do|ado|if|then|else|case|of|let|in)(?!\')\\b'
   }
   {
     'name': 'constant.numeric.float.purescript'


### PR DESCRIPTION
This PR adds the `ado` keyword added to PureScript in 0.12.