### PR TITLE
highlight `unit` as a language constant, like `true` and `false`

### DIFF
--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -267,6 +267,10 @@
     'match': '\\b(true|false)\\b'
   }
   {
+    'name': 'constant.language.unit.purescript'
+    'match': '\\b(unit)\\b'
+  }
+  {
     'name': 'constant.numeric.purescript'
     'match': '\\b([0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\\b'
   }


### PR DESCRIPTION
This PR highlights the builtin `unit` value as a language constant, just as `true` and `false`.