### PR TITLE
Fix Syntax-Highlighting for `_` in Numbers

### DIFF
--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -262,7 +262,7 @@
   }
   {
     'name': 'constant.numeric.float.purescript'
-    'match': '\\b([0-9]+\\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\\b'
+    'match': '\\b(([0-9]+_?)+[0-9]+\\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\\b'
   }
   {
     'name': 'constant.language.boolean.purescript'
@@ -270,7 +270,7 @@
   }
   {
     'name': 'constant.numeric.purescript'
-    'match': '\\b([0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\\b'
+    'match': '\\b(([0-9]+_?)+[0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\\b'
   }
   {
     'name': 'string.quoted.triple.purescript'

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -262,7 +262,7 @@
   }
   {
     'name': 'constant.numeric.float.purescript'
-    'match': '\\b((([0-9]+_?)+[0-9]+|[0-9]+)\\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\\b'
+    'match': '\\b(([0-9]+_?)*[0-9]+\\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\\b'
   }
   {
     'name': 'constant.language.boolean.purescript'
@@ -270,7 +270,7 @@
   }
   {
     'name': 'constant.numeric.purescript'
-    'match': '\\b(([0-9]+_?)+[0-9]+|[0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\\b'
+    'match': '\\b(([0-9]+_?)*[0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\\b'
   }
   {
     'name': 'string.quoted.triple.purescript'

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -262,7 +262,7 @@
   }
   {
     'name': 'constant.numeric.float.purescript'
-    'match': '\\b(([0-9]+_?)+[0-9]+\\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\\b'
+    'match': '\\b((([0-9]+_?)+[0-9]+|[0-9]+)\\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\\b'
   }
   {
     'name': 'constant.language.boolean.purescript'
@@ -270,7 +270,7 @@
   }
   {
     'name': 'constant.numeric.purescript'
-    'match': '\\b(([0-9]+_?)+[0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\\b'
+    'match': '\\b(([0-9]+_?)+[0-9]+|[0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\\b'
   }
   {
     'name': 'string.quoted.triple.purescript'

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -237,14 +237,14 @@ purescriptGrammar =
       match: /\b(do|ado|if|then|else|case|of|let|in)(?!')\b/
     ,
       name: 'constant.numeric.float'
-      match: /\b((([0-9]+_?)+[0-9]+|[0-9]+)\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\b/
+      match: /\b(([0-9]+_?)*[0-9]+\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\b/
       # Floats are always decimal
     ,
       name: 'constant.language.boolean'
       match: /\b(true|false)\b/
     ,
       name: 'constant.numeric'
-      match: /\b(([0-9]+_?)+[0-9]+|[0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\b/
+      match: /\b(([0-9]+_?)*[0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\b/
     ,
       name: 'string.quoted.triple'
       begin: /"""/

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -237,14 +237,14 @@ purescriptGrammar =
       match: /\b(do|ado|if|then|else|case|of|let|in)(?!')\b/
     ,
       name: 'constant.numeric.float'
-      match: /\b([0-9]+\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\b/
+      match: /\b((([0-9]+_?)+[0-9]+|[0-9]+)\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\b/
       # Floats are always decimal
     ,
       name: 'constant.language.boolean'
       match: /\b(true|false)\b/
     ,
       name: 'constant.numeric'
-      match: /\b([0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\b/
+      match: /\b(([0-9]+_?)+[0-9]+|[0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\b/
     ,
       name: 'string.quoted.triple'
       begin: /"""/


### PR DESCRIPTION
Purescript has added, that numeric literals can contain `_`, which the syntax highlighting did not pickup

Release Notes of Version, that added this: https://github.com/purescript/purescript/releases/tag/v0.13.0

`1_2_3_4.5` and `1_2_3_4` should be highlighted as a Number, but were not. This PR fixes that