### PR TITLE
Fix keywords beg

### DIFF
--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -32,7 +32,7 @@
   }
   {
     'name': 'meta.declaration.module.purescript'
-    'begin': '\\b(module)(?!\')\\b'
+    'begin': '^\\s*\\b(module)(?!\')\\b'
     'end': '(where)'
     'beginCaptures':
       '1':
@@ -58,7 +58,7 @@
   }
   {
     'name': 'meta.declaration.typeclass.purescript'
-    'begin': '\\b(class)(?!\')\\b'
+    'begin': '^\\s*\\b(class)(?!\')\\b'
     'end': '\\b(where)\\b|$'
     'beginCaptures':
       '1':
@@ -74,13 +74,15 @@
   }
   {
     'name': 'meta.declaration.instance.purescript'
-    'begin': '\\b(else\\s+)?(instance)(?!\')\\b'
+    'begin': '^\\s*\\b(else\\s+)?(derive\\s+)?(instance)(?!\')\\b'
     'end': '\\b(where)\\b|$'
     'contentName': 'meta.type-signature.purescript'
     'beginCaptures':
       '1':
         'name': 'keyword.other.purescript'
       '2':
+        'name': 'keyword.other.purescript'
+      '3':
         'name': 'keyword.other.purescript'
     'endCaptures':
       '1':
@@ -139,7 +141,7 @@
   }
   {
     'name': 'meta.import.purescript'
-    'begin': '\\b(import)(?!\')\\b'
+    'begin': '^\\s*\\b(import)(?!\')\\b'
     'end': '($|(?=--))'
     'beginCaptures':
       '1':
@@ -246,7 +248,7 @@
   }
   {
     'name': 'keyword.other.purescript'
-    'match': '\\b(derive|where|data|type|newtype|infix[lr]?|foreign)(?!\')\\b'
+    'match': '^\\s*\\b(derive|where|data|type|newtype|infix[lr]?|foreign(\\s+import)?(\\s+data)?)(?!\')\\b'
   }
   {
     'name': 'entity.name.function.typed-hole.purescript'
@@ -254,11 +256,11 @@
   }
   {
     'name': 'storage.type.purescript'
-    'match': '\\b(data|type|newtype)(?!\')\\b'
+    'match': '^\\s*\\b(data|type|newtype)(?!\')\\b'
   }
   {
     'name': 'keyword.control.purescript'
-    'match': '\\b(do|ado|if|then|else|case|of|let|in)(?!\')\\b'
+    'match': '\\b(do|ado|if|then|else|case|of|let|in)(?!(\'|\\s*(:|=)))\\b'
   }
   {
     'name': 'constant.numeric.hex.purescript'

--- a/grammars/purescript.cson
+++ b/grammars/purescript.cson
@@ -74,7 +74,7 @@
   }
   {
     'name': 'meta.declaration.instance.purescript'
-    'begin': '^\\s*\\b(else\\s+)?(derive\\s+)?(instance)(?!\')\\b'
+    'begin': '^\\s*\\b(else\\s+)?(derive\\s+)?(newtype\\s+)?(instance)(?!\')\\b'
     'end': '\\b(where)\\b|$'
     'contentName': 'meta.type-signature.purescript'
     'beginCaptures':
@@ -83,6 +83,8 @@
       '2':
         'name': 'keyword.other.purescript'
       '3':
+        'name': 'keyword.other.purescript'
+      '4':
         'name': 'keyword.other.purescript'
     'endCaptures':
       '1':

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -88,7 +88,7 @@ purescriptGrammar =
       ###
     ,
       name: 'meta.declaration.module'
-      begin: /\b(module)(?!')\b/
+      begin: /^\s*\b(module)(?!')\b/
       end: /(where)/
       beginCaptures:
         1: name: 'keyword.other'
@@ -106,7 +106,7 @@ purescriptGrammar =
       ]
     ,
       name: 'meta.declaration.typeclass'
-      begin: /\b(class)(?!')\b/
+      begin: /^\s*\b(class)(?!')\b/
       end: /\b(where)\b|$/
       beginCaptures:
         1: name: 'storage.type.class'
@@ -116,13 +116,14 @@ purescriptGrammar =
         include: '#type_signature'
       ]
     ,
-      name: 'meta.declaration.instance'
-      begin: /\b(else\s+)?(instance)(?!')\b/
+      name: 'meta.declaration.instance'      
+      begin: /^\s*\b(else\s+)?(derive\s+)?(instance)(?!')\b/
       end: /\b(where)\b|$/
       contentName: 'meta.type-signature'
       beginCaptures:
         1: name: 'keyword.other'
         2: name: 'keyword.other'
+        3: name: 'keyword.other'
       endCaptures:
         1: name: 'keyword.other'
       patterns: [
@@ -160,7 +161,7 @@ purescriptGrammar =
       ]
     ,
       name: 'meta.import'
-      begin: /\b(import)(?!')\b/
+      begin: /^\s*\b(import)(?!')\b/
       end: /($|(?=--))/
       beginCaptures:
         1: name: 'keyword.other'
@@ -224,17 +225,20 @@ purescriptGrammar =
           include: '#comments'
       ]
     ,
-      name: 'keyword.other'
-      match: /\b(derive|where|data|type|newtype|infix[lr]?|foreign)(?!')\b/
+      name: 'keyword.other'      
+      match: /^\s*\b(derive|where|data|type|newtype|infix[lr]?|foreign(\s+import)?(\s+data)?)(?!')\b/
     ,
       name: 'entity.name.function.typed-hole'
       match: /\?(?:{functionNameOne}|{classNameOne})/
     ,
       name: 'storage.type'
-      match: /\b(data|type|newtype)(?!')\b/
+      match: /^\s*\b(data|type|newtype)(?!')\b/
     ,
       name: 'keyword.control'
-      match: /\b(do|ado|if|then|else|case|of|let|in)(?!')\b/
+      # match only if a keyword is not followed by:
+      # ' - names with prime symbol
+      #  `:` or `=` -  records define/update
+      match: /\b(do|ado|if|then|else|case|of|let|in)(?!('|\s*(:|=)))\b/
     ,
       name: 'constant.numeric.hex.purescript',
       match: '\\b(?<!\\$)0(x|X)[0-9a-fA-F]+\\b(?!\\$)'

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -117,13 +117,14 @@ purescriptGrammar =
       ]
     ,
       name: 'meta.declaration.instance'      
-      begin: /^\s*\b(else\s+)?(derive\s+)?(instance)(?!')\b/
+      begin: /^\s*\b(else\s+)?(derive\s+)?(newtype\s+)?(instance)(?!')\b/
       end: /\b(where)\b|$/
       contentName: 'meta.type-signature'
       beginCaptures:
         1: name: 'keyword.other'
         2: name: 'keyword.other'
         3: name: 'keyword.other'
+        4: name: 'keyword.other'
       endCaptures:
         1: name: 'keyword.other'
       patterns: [

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -49,7 +49,7 @@ class Functor v <= Mountable vnode where
 
 
 derive instance newtypeMySub :: Newtype (MySub vnode msg) _
-
+derive newtype instance semiringScore :: Semiring Score
 
 derive instance genericCmd :: Generic PhonerCmd _
 instance encodeCmd :: EncodeJson PhonerCmd where
@@ -81,6 +81,7 @@ else instance showBoolean :: MyShow Boolean where
 else instance showA :: MyShow a where
   myShow _ = "Invalid"
 
+else newtype instance showA :: MyShow a where
 
 -- Records with fields that are reserved words
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,218 @@
+{- Test file to visually assess syntax highlighting. -}
+module Main.App where
+module Main.App
+  ( main
+  ) where
+
+
+import Prelude
+
+import Data.String as String
+import Data.String (Pattern)
+import Data.String (Pattern(..), split)
+
+
+-- Foreign import
+foreign
+foreign import
+foreign import data
+foreign import calculateInterest :: Number -> Number
+foreign import data F :: Type
+
+
+-- Containers
+
+
+data D a = D1 a | D2 String
+
+
+type T = { a :: String }
+type T a = { n :: N a, b :: String }
+
+
+newtype N a = N a
+
+
+-- infix -- TODO: as
+
+
+infixr 0 apply as <|
+infixl 0 applyFlipped as |>
+
+
+-- Type class
+
+
+class Functor v <= Mountable vnode where
+  mount :: ∀ m. Element -> T Void (v m)
+  unmount :: ∀ m. v m -> v m -> T Void E
+
+
+derive instance newtypeMySub :: Newtype (MySub vnode msg) _
+
+
+derive instance genericCmd :: Generic PhonerCmd _
+instance encodeCmd :: EncodeJson PhonerCmd where
+  encodeJson a = genericEncodeJson a
+
+
+instance functorA :: Functor A where
+   map = split
+
+
+instance functorA :: Functor A where
+   map = split
+
+
+-- chained instances
+
+
+class MyShow a where
+  myShow :: a -> String
+
+
+instance showString :: MyShow String where
+  myShow s = s
+
+
+else instance showBoolean :: MyShow Boolean where
+  myShow true = "true"
+  myShow false = "false"
+else instance showA :: MyShow a where
+  myShow _ = "Invalid"
+
+
+-- Records with fields that are reserved words
+
+
+type Rec =
+  { module :: String
+  , import :: String
+  , data :: String
+  , newtype :: String
+  }
+
+
+-- https://github.com/purescript/purescript-in-purescript/blob/master/src/Language/PureScript/Keywords.purs
+rec =
+  { data: "data"
+  , type: "type"
+  , foreign: "foreign"
+  , import: "import"
+  , infixl: "infixl"
+  , infixr: "infixr"
+  , infix: "infix"
+  , class: "class"
+  , instance: "instance"
+  , case: case some of _ -> 1
+  , of: "of"
+  , if: "if"
+  , then: "then"
+  , else: "else"
+  , do: "do"
+  , let: "let"
+  -- no big reason to strive to make true/false not highlighted here
+  , true: "true"
+  , false: "false"
+  , in: "in"
+  , where: "where"
+  , forall: "forall"
+  , module: "module"
+  }
+
+
+updateRec = rec
+  { data = "data"
+  , type ="type"
+  , foreign = "foreign"
+  , import = "import"
+  , infixl = "infixl"
+  , infixr = "infixr"
+  , infix = "infix"
+  , class = "class"
+  , instance = "instance"
+  , case = case some of _ -> 1
+  , of = "of"
+  , if = if true then "true" else "false"
+  , then = "then"
+  , else = "else"
+  , do = "do"
+  , let = "let"
+  , true = true
+  , false = false
+  , in = "in"
+  , where = "where"
+  , forall = "forall"
+  , module = "module"
+  }
+
+
+-- quoted row type
+type QuotedRow =
+  ( "A" :: Int
+  , "B" :: Number
+  )
+
+-- quoted record type
+type Quoted =
+  { "A" :: Int
+  , "B" :: Number
+  }
+
+
+-- quoted row type
+quoted =
+  { "A": "a"
+  , "B": 1
+  }
+
+
+-- Function, forall
+
+
+-- do, where
+toStr :: forall a. a -> Effect Unit
+toStr x = do
+  log $ show num
+  log $ show str
+  where
+  num = 1
+  str = "Str"
+
+
+addIf true = singleton
+addIf false = const []
+
+
+-- let in, case of
+fn
+  :: forall a. a -> String
+fn a =
+  let b = "str"
+  in case a of
+    "1" -> b + "1"
+    _ -> b + a
+
+
+-- if' fn and if statement with
+if' = if true then "false" else "true"
+
+
+-- true'
+true' = if false then "false" else "true"
+
+
+-- false'
+false' = if false then true' else "false"
+
+
+case' = if true
+  then if'
+  else "true"
+
+
+--
+type Schema
+  = {
+    , widgets :: { id :: Int } ==> Array Widget
+    }


### PR DESCRIPTION
Added keyword syntax fixes, most of the keywords like module, data, type are legal only at the beginning of the line and can be used for example as record field names. Example of changes:

![image](https://user-images.githubusercontent.com/736697/116781558-0bd49280-aa9d-11eb-9f27-6c599283418d.png)

Added Test file `Main.purs` where changes could be visually assessed. File contains legal/incomplete syntax cases, so it is better to turn off errors highlighting.