### PR TITLE
Grammar update 2

### DIFF
--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -403,7 +403,7 @@ purescriptGrammar =
         patterns: [
             include: '#comments'
           ,
-            include: '#type_name'
+            include: '#data_ctor'
           ,
             name: 'constant.numeric'
             match: /\d+/
@@ -411,6 +411,11 @@ purescriptGrammar =
             match: /({operator})/
             captures:
               1: name: 'keyword.other'
+          ,
+            match: /\b(type)\s+({className})\b/
+            captures:
+              1: name: 'keyword.other'
+              2: name: 'entity.name.type'
           ,
             match: /\b(as|type)\b/
             captures:

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -115,8 +115,6 @@ purescriptGrammar =
     ,
       include: '#infix_op'
     ,
-      include: '#double_colon_inlined_signature'
-    ,
       include: '#constants_numeric_decimal'
     ,
       include: '#constant_numeric'
@@ -134,9 +132,11 @@ purescriptGrammar =
     ,
       include: '#double_colon_parens'
     ,
+      include: '#double_colon_inlined'
+    ,
       include: '#double_colon_orphan'
     ,
-     include: '#comments'
+      include: '#comments'
     ,
       name: 'keyword.other.arrow'
       match: /\<-|-\>/
@@ -535,42 +535,45 @@ purescriptGrammar =
           0: name: 'punctuation.definition.string.end'
       ]
 
-    # double_colon_parens:
-    #   patterns: [
-    #     # Note recursive regex matching nested parens
-    #     match: [
-    #       '\\(',
-    #       '(?<paren>(?:[^()]|\\(\\g<paren>\\))*)',
-    #       '(::|∷)',
-    #       '(?<paren2>(?:[^()]|\\(\\g<paren2>\\))*)',
-    #       '\\)'
-    #     ].join('')
-    #     captures:
-    #       1: patterns: [
-    #           include: '$self'
-    #         ]
-    #       2: name: 'keyword.other.double-colon'
-    #       3: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
-    #   ]
-
-    double_colon_inlined_signature:
+    # for inline signatures with parens
+    double_colon_parens:
       patterns: [
-        patterns: [
-          match: '(SomeType)\s*({doubleColon})(.*)'
-          captures:
-            1: name: 'meta.type-signature'
-            2: name: 'keyword.other.double-colon'
-            3: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
+        # Note recursive regex matching nested parens
+        match: [
+          '\\(',
+          '(?<paren>(?:[^()]|\\(\\g<paren>\\))*)',
+          '(::|∷)',
+          '(?<paren2>(?:[^()]|\\(\\g<paren2>\\))*)',
+          '\\)'
+        ].join('')
+        captures:
+          1: patterns: [
+              include: '$self'
+            ]
+          2: name: 'keyword.other.double-colon'
+          3: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
+      ]
 
-        ]
-      ,
+    # for inline signatures without parens
+    double_colon_inlined:
+      patterns: [
+      # signatures in ide tooptips (starts from new line)
+      #   patterns: [
+      #     match: '^({classNameOne})(?: +)({doubleColon})(.*)'
+      #     captures:
+      #       1: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
+      #       2: name: 'keyword.other.double-colon'
+      #       3: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
+      #   ]
+      # ,
         patterns: [
-          match: '({doubleColon})(.*)(<-)'
+          match: '({doubleColon})(.*)(?=<-|")'
           captures:
             1: name: 'keyword.other.double-colon'
-            2: {name: 'meta.type-signature', patterns: [ include: '#type_signature']}
-            3: name: 'keyword.other.double-colon'
+            2: {name: 'meta.type-signature', patterns: [
+              include: '#type_signature'
 
+            ]}
         ]
       ,
         patterns: [
@@ -587,61 +590,13 @@ purescriptGrammar =
 
         ]
       ]
-
-    _double_colon_inlined_signature:
-      patterns: [
-        # Note recursive regex matching nested parens
-        # match: '\\((?<paren>(?:[^()]|\\(\\g<paren>\\))*)(::|∷)(?<paren2>(?:[^()]|\\(\\g<paren2>\\))*)\\)'
-        match: [
-          # '\\(',
-          # '(?<paren>(?:[^()]|\\(\\g<paren>\\))*)',
-          '(::|∷)',
-          #'(?<paren2>(?:[^()]|\\(\\g<paren2>\\))*)',
-          '(.*)',
-          # '\\)'
-        ].join('')
-        captures:
-          # 1: patterns: [
-          #     include: '$self'
-          #   ]
-          1: name: 'keyword.other.double-colon'
-          2: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
-      ]
-
-    double_colon_parens:
-      patterns: [
-        # Note recursive regex matching nested parens
-        # Here we will only match parens with :: inside
-        match: [
-          '\\(',
-          # '(?<paren>(?:[^()]|\\(\\g<paren>\\))*)',
-          '(?<paren>(?:[^()]*(::|∷)[^()]*|\\(\\g<paren>\\)*))',
-          # '(::|∷)',
-          # '(?<paren2>(?:[^()]|\\(\\g<paren2>\\))*)',
-          '\\)'
-        ].join('')
-        # match: [
-        #   '\\((?<paren>(?:[^()]|\\(\\g<paren>\\))*)',
-        #   '(::|∷)',
-        #   '(?<paren2>(?:[^()]|\\(\\g<paren2>\\))*)',
-        #   '\\)'
-        # ].join('')
-        captures:
-          1: patterns: [
-            #   include: "#string_double_quoted"
-            # ,
-            #   include: '#double_colon_inlined_signature'
-            #,
-              include: '$self'
-            ]
-      ]
-
     double_colon_orphan:
       patterns: [
         begin: ///
-          ^
           ( \s* )
           (?: ( :: | ∷ ) )
+          ( \s* )
+          $
           ///
         beginCaptures:
           2: name: 'keyword.other.double-colon'
@@ -653,6 +608,23 @@ purescriptGrammar =
             include: '#type_signature'
         ]
       ]
+    # double_colon_orphan:
+    #   patterns: [
+    #     begin: ///
+    #       ^
+    #       ( \s* )
+    #       (?: ( :: | ∷ ) )
+    #       ///
+    #     beginCaptures:
+    #       2: name: 'keyword.other.double-colon'
+    #     end: ///
+    #       ^
+    #       (?! \1 {indentChar}* | {indentChar}* $ )
+    #       ///
+    #     patterns: [
+    #         include: '#type_signature'
+    #     ]
+    #   ]
 
     markup_newline:
       patterns: [
@@ -793,14 +765,21 @@ purescriptGrammar =
         because there doesn't seem to be a correct way to distinguish row type declaration
         from another types put in brackets.
         ###
-        begin: /\((?= \s*({functionNameOne}|"{functionNameOne}"|"{classNameOne}")\s*(::|∷))/
-        end: / \)/
+        # begin: /\((?= \s*({functionNameOne}|"{functionNameOne}"|"{classNameOne}")\s*(::|∷))/
+        # end: / \)/
+        begin: /\((?=\s*({functionNameOne}|"{functionNameOne}"|"{classNameOne}")\s*(::|∷))/
+        end: /(?=^\S)/
+
         #applyEndPatternsLast: true
         patterns: [
-          #   name: 'punctuation.separator.comma.purescript'
-          #   match: ','
-          # ,
-           include: '#record_field_declaration'
+            name: 'punctuation.separator.comma.purescript'
+            match: ','
+          ,
+            include: '#comments'
+          ,
+            include: '#record_field_declaration'
+          ,
+            include: '#type_signature'
         ]
       ]
 
@@ -821,8 +800,11 @@ purescriptGrammar =
             match: ','
           ,
             include: '#comments'
+
           ,
             include: '#record_field_declaration'
+          ,
+            include: '#type_signature'
          ]
       ]
 
@@ -830,7 +812,7 @@ purescriptGrammar =
       name: 'meta.record-field.type-declaration'
       begin: /{recordFieldDeclaration}/
       # we use end pattern of " )" with space (as as row type ending)
-      end: /(?={recordFieldDeclaration}|}| \))/
+      end: /(?={recordFieldDeclaration}|}| \)|{indentBlockEnd})/
       # applyEndPatternsLast: true
       contentName: 'meta.type-signature'
       beginCaptures:
@@ -845,16 +827,13 @@ purescriptGrammar =
           ]
         2: name: 'keyword.other.double-colon'
       patterns: [
-        #   # row type pipe
-        #   match: /\|(?=\s*{functionNameOne})/
-        #   captures:
-        #     0: name: 'punctuation.separator.pipe'
-        # ,
          include: '#record_types'
         # ,
         #   include: '#row_types'
         ,
           include: '#type_signature'
+        # ,
+        #   include: '#record_field_declaration'
         ,
           include: '#comments'
       ]
@@ -878,8 +857,8 @@ purescriptGrammar =
       patterns: [
          include: "#record_types"
         ,
-         include: '#row_types'
-        ,
+        #  include: '#row_types'
+        # ,
           name: 'meta.class-constraints'
           match: concat /\(/,
             list('classConstraints',/{classConstraint}/,/,/),

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -124,11 +124,12 @@ purescriptGrammar =
     ,
       include: '#constant_boolean'
     ,
+      ### Triple quotes should come first to enclose inner quotes ###
+      include: '#string_triple_quoted'
+    ,
       include: '#string_single_quoted'
     ,
       include: '#string_double_quoted'
-    ,
-      include: '#string_triple_quoted'
     ,
       include: '#markup_newline'
     ,

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -87,7 +87,6 @@ purescriptGrammar =
     ,
       include: '#type_synonym_declaration'
     ,
-      # data and newtype
       include: '#data_type_declaration'
     ,
       include: '#typeclass_declaration'
@@ -116,6 +115,8 @@ purescriptGrammar =
     ,
       include: '#infix_op'
     ,
+      include: '#double_colon_inlined_signature'
+    ,
       include: '#constants_numeric_decimal'
     ,
       include: '#constant_numeric'
@@ -136,8 +137,6 @@ purescriptGrammar =
       include: '#double_colon_orphan'
     ,
      include: '#comments'
-    ,
-      include: '#double_colon_inlined_signature'
     ,
       name: 'keyword.other.arrow'
       match: /\<-|-\>/
@@ -551,7 +550,43 @@ purescriptGrammar =
 
     double_colon_inlined_signature:
       patterns: [
+        patterns: [
+          match: '(SomeType)\s*({doubleColon})(.*)'
+          captures:
+            1: name: 'meta.type-signature'
+            2: name: 'keyword.other.double-colon'
+            3: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
+
+        ]
+      ,
+        patterns: [
+          match: '({doubleColon})(.*)(<-)'
+          captures:
+            1: name: 'keyword.other.double-colon'
+            2: {name: 'meta.type-signature', patterns: [ include: '#type_signature']}
+            3: name: 'keyword.other.double-colon'
+
+        ]
+      ,
+        patterns: [
+          match: '({doubleColon})(.*)'
+          captures:
+            1: name: 'keyword.other.double-colon'
+            2: {
+              name: 'meta.type-signature'
+              patterns: [
+                include: "#record_types"
+                include: '#type_signature'
+              ]
+            }
+
+        ]
+      ]
+
+    _double_colon_inlined_signature:
+      patterns: [
         # Note recursive regex matching nested parens
+        # match: '\\((?<paren>(?:[^()]|\\(\\g<paren>\\))*)(::|∷)(?<paren2>(?:[^()]|\\(\\g<paren2>\\))*)\\)'
         match: [
           # '\\(',
           # '(?<paren>(?:[^()]|\\(\\g<paren>\\))*)',
@@ -836,8 +871,10 @@ purescriptGrammar =
       ]
     type_signature:
       patterns: [
-        #   include: '#row_types'
-        # ,
+         include: "#record_types"
+        ,
+         include: '#row_types'
+        ,
           name: 'meta.class-constraints'
           match: concat /\(/,
             list('classConstraints',/{classConstraint}/,/,/),

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -84,8 +84,6 @@ purescriptGrammar =
       include: '#module_declaration'
     ,
       include: '#module_import'
-    # ,
-    #   include: '#type_kind_signature'
     ,
       include: '#type_synonym_declaration'
     ,
@@ -137,7 +135,7 @@ purescriptGrammar =
     ,
       include: '#double_colon_orphan'
     ,
-      include: '#comments'
+     include: '#comments'
     ,
       include: '#double_colon_inlined_signature'
     ,
@@ -650,25 +648,29 @@ purescriptGrammar =
 
     comments:
       patterns: [
-          begin: /({maybeBirdTrack}[ \t]+)?(?=--+\s+\|)/
-          end: /(?!\G)/
-          beginCaptures:
-            1: name: 'punctuation.whitespace.comment.leading'
-          patterns: [
-              name: 'comment.line.double-dash.documentation'
-              begin: /(--+)\s+(\|)/
-              end: /\n/
-              beginCaptures:
-                1: name: 'punctuation.definition.comment'
-                2: name: 'punctuation.definition.comment.documentation'
-          ]
-        ,
+        #   begin: /({maybeBirdTrack}[ \t]+)?(?=--+\s*\|)/
+        #   #begin: / --/
+        #   # begin: /({maybeBirdTrack}[ \t]+)?(?=--+)/
+        #   end: /(?!\G)/
+        #   beginCaptures:
+        #     1: name: 'punctuation.whitespace.comment.leading'
+        #   patterns: [
+        #       name: 'comment.line.double-dash.documentation'
+        #       begin: /(--+)\s*(\|)/
+        #       # begin: /(--+)/
+        #       end: /\n/
+        #       beginCaptures:
+        #         1: name: 'punctuation.definition.comment'
+        #         2: name: 'punctuation.definition.comment.documentation'
+        #   ]
+        # ,
           ###
           Operators may begin with -- as long as they are not
           entirely composed of - characters. This means comments can't be
           immediately followed by an allowable operator character.
           ###
-          begin: /({maybeBirdTrack}[ \t]+)?(?=--+(?!{operatorChar}))/
+          # begin: /({maybeBirdTrack}[ \t]+)?(?=--+(?!{operatorChar}))/
+          begin: /({maybeBirdTrack}[ \t]+)?(?=--+)/
           end: /(?!\G)/
           beginCaptures:
             1: name: 'punctuation.whitespace.comment.leading'
@@ -765,7 +767,8 @@ purescriptGrammar =
     record_types:
       patterns: [
         name: 'meta.type.record'
-        begin: '\\{'
+        # start with {, but not block comment
+        begin: '\\{(?!-)'
         beginCaptures:
           0:
             name: 'keyword.operator.type.record.begin.purescript'
@@ -777,9 +780,9 @@ purescriptGrammar =
             name: 'punctuation.separator.comma.purescript'
             match: ','
           ,
-            include: '#record_field_declaration'
-          ,
             include: '#comments'
+          ,
+            include: '#record_field_declaration'
          ]
       ]
 

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -64,7 +64,7 @@ purescriptGrammar =
     # record field may be quoted string
     recordFieldQuoted: /"(?:{className}|{functionNameOne})"/
     recordFieldDeclaration:
-      /((?:{recordFieldQuoted})|{functionNameOne})\s*(::|∷)/
+      /((?:[ ,])(?:{recordFieldQuoted})|{functionNameOne})\s*(::|∷)/
     ctorArgs: ///
       (?:
       {className}     #proper type
@@ -251,8 +251,10 @@ purescriptGrammar =
           6: name: 'keyword.other.double-colon'
         patterns: [
           include: '#comments'
-          ,
+        ,
           include: '#type_signature'
+        ,
+          include: '#record_types'
         ]
       ]
 
@@ -270,6 +272,8 @@ purescriptGrammar =
             include: '#double_colon'
           ,
             include: '#type_signature'
+          ,
+            include: '#record_types'
         ]
       ]
 
@@ -282,6 +286,8 @@ purescriptGrammar =
           1: name: 'keyword.other'
         patterns: [
             include: '#module_name'
+          ,
+            include: "#string_double_quoted"
           ,
             include: '#comments'
           ,
@@ -381,9 +387,9 @@ purescriptGrammar =
           ,
             include: '#type_signature'
           ,
-            include: '#row_type'
-          ,
             include: '#record_types'
+          ,
+            include: '#row_types'
           ,
             include: '#comments'
         ]
@@ -732,31 +738,26 @@ purescriptGrammar =
           include: '#type_signature'
         ,
           include: '#record_types'
+        ,
+          include: '#row_types'
       ]
 
-    row_type:
+    row_types:
       patterns: [
         name: 'meta.type.row'
-        # as row paren follows after = or type name or starts in a new line
-        # begin: /(?<=(^|=|{classNameOne})\s*)\(/
-        begin: /\((?=\s*({functionNameOne}|"{functionNameOne}"|"{classNameOne}")\s*(::|∷))/
-        # beginCaptures:
-        #   0: name: 'keyword.operator.type.row.begin.purescript'
-        end: /\)/
-        applyEndPatternsLast: true
-        # endCaptures:
-        #   0: name: 'keyword.operator.type.row.end.purescript'
+        ###
+        For distinction of row type we use pattern with a space after/before a bracket,
+        because there doesn't seem to be a correct way to distinguish row type declaration
+        from another types put in brackets.
+        ###
+        begin: /\((?= \s*({functionNameOne}|"{functionNameOne}"|"{classNameOne}")\s*(::|∷))/
+        end: / \)/
+        #applyEndPatternsLast: true
         patterns: [
-            name: 'punctuation.separator.comma.purescript'
-            match: ','
-          ,
-            include: '#row_type'
-          ,
-            include: '#record_field_declaration'
-          ,
-            include: '#type_signature'
-          ,
-            include: '#comments'
+          #   name: 'punctuation.separator.comma.purescript'
+          #   match: ','
+          # ,
+           include: '#record_field_declaration'
         ]
       ]
 
@@ -784,7 +785,9 @@ purescriptGrammar =
     record_field_declaration:
       name: 'meta.record-field.type-declaration'
       begin: /{recordFieldDeclaration}/
-      end: /(?={recordFieldDeclaration}|}|\))/
+      # we use end pattern of " )" with space (as as row type ending)
+      end: /(?={recordFieldDeclaration}|}| \))/
+      # applyEndPatternsLast: true
       contentName: 'meta.type-signature'
       beginCaptures:
         1:
@@ -792,8 +795,9 @@ purescriptGrammar =
               name: 'entity.other.attribute-name'
               match: /{functionName}/
             ,
+              # match quoated props
               name: 'string.quoted.double'
-              match: /"{functionNameOne}|{classNameOne}"/
+              match: /\"({functionNameOne}|{classNameOne})\"/
           ]
         2: name: 'keyword.other.double-colon'
       patterns: [
@@ -802,11 +806,13 @@ purescriptGrammar =
         #   captures:
         #     0: name: 'punctuation.separator.pipe'
         # ,
+         include: '#record_types'
+        # ,
+        #   include: '#row_types'
+        ,
           include: '#type_signature'
         ,
           include: '#comments'
-        ,
-          include: '#record_types'
       ]
 
     # this can probalby be removed as we can use type_signature instead
@@ -826,10 +832,8 @@ purescriptGrammar =
       ]
     type_signature:
       patterns: [
-          include: '#string_double_quoted'
-        ,
-          include: '#row_type'
-        ,
+        #   include: '#row_types'
+        # ,
           name: 'meta.class-constraints'
           match: concat /\(/,
             list('classConstraints',/{classConstraint}/,/,/),
@@ -857,6 +861,8 @@ purescriptGrammar =
         ,
           name: 'keyword.other.forall'
           match: /forall|∀/
+        ,
+          include: '#string_double_quoted'
         ,
           include: '#generic_type'
         ,

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -84,8 +84,8 @@ purescriptGrammar =
       include: '#module_declaration'
     ,
       include: '#module_import'
-    ,
-      include: '#type_kind_signature'
+    # ,
+    #   include: '#type_kind_signature'
     ,
       include: '#type_synonym_declaration'
     ,
@@ -344,13 +344,13 @@ purescriptGrammar =
             match: /=/
             captures:
               0: name: 'keyword.operator.assignment'
-          ,
-            match: /{ctor}/
+          # ,
+            match: /(?<=(\||=)\s*)({classNameOne})/
             captures:
-              1: patterns: [include: '#data_ctor']
-              2:
-                name: 'meta.type-signature'
-                patterns: [include: '#type_signature']
+              2: patterns: [include: '#data_ctor']
+              # 2:
+              #   name: 'meta.type-signature'
+              #   patterns: [include: '#type_signature']
           ,
             match: /\|/
             captures:
@@ -358,6 +358,8 @@ purescriptGrammar =
               0: name: 'keyword.operator.pipe'
           ,
             include: '#record_types'
+          ,
+            include: '#type_signature'
         ]
       ]
 
@@ -736,7 +738,8 @@ purescriptGrammar =
       patterns: [
         name: 'meta.type.row'
         # as row paren follows after = or type name or starts in a new line
-        begin: /(?<=(^|=|{classNameOne})\s*)\(/
+        # begin: /(?<=(^|=|{classNameOne})\s*)\(/
+        begin: /\((?=\s*({functionNameOne}|"{functionNameOne}"|"{classNameOne}")\s*(::|∷))/
         # beginCaptures:
         #   0: name: 'keyword.operator.type.row.begin.purescript'
         end: /\)/
@@ -824,6 +827,8 @@ purescriptGrammar =
     type_signature:
       patterns: [
           include: '#string_double_quoted'
+        ,
+          include: '#row_type'
         ,
           name: 'meta.class-constraints'
           match: concat /\(/,

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -321,7 +321,8 @@ purescriptGrammar =
           ,
             match: /\|/
             captures:
-              0: name: 'punctuation.separator.pipe'
+              # 0: name: 'punctuation.separator.pipe'
+              0: name: 'keyword.operator.pipe'
           ,
             include: '#record_types'
         ]
@@ -353,7 +354,8 @@ purescriptGrammar =
           ,
             match: /\|/
             captures:
-              0: name: 'punctuation.separator.pipe'
+              # 0: name: 'punctuation.separator.pipe'
+              0: name: 'keyword.operator.pipe'
           ,
             include: '#record_types'
         ]

--- a/src/purescript.coffee
+++ b/src/purescript.coffee
@@ -61,6 +61,10 @@ purescriptGrammar =
       list('classConstraint',/{className}|{functionName}/,/\s+/)
     functionTypeDeclaration:
       /({functionNameOne})\s*(::|∷)/
+    # record field may be quoted string
+    recordFieldQuoted: /"(?:{className}|{functionNameOne})"/
+    recordFieldDeclaration:
+      /((?:{recordFieldQuoted})|{functionNameOne})\s*(::|∷)/
     ctorArgs: ///
       (?:
       {className}     #proper type
@@ -74,281 +78,67 @@ purescriptGrammar =
     indentChar: /[ \t]/
     indentBlockEnd: /^(?!\1{indentChar}|{indentChar}*$)/
     maybeBirdTrack: /^/
+    doubleColon: ///(?: :: | ∷ )///
 
   patterns: [
-      name: 'keyword.operator.function.infix'
-      match: /(`){functionName}(`)/
-      captures:
-        1: name: 'punctuation.definition.entity'
-        2: name: 'punctuation.definition.entity'
-      ###
-      In case this regex seems unusual for an infix operator, note
-      that PureScript allows any ordinary function application (elem 4 (1..10))
-      to be rewritten as an infix expression (4 `elem` (1..10)).
-      ###
+      include: '#module_declaration'
     ,
-      name: 'meta.declaration.module'
-      begin: /^\s*\b(module)(?!')\b/
-      end: /(where)/
-      beginCaptures:
-        1: name: 'keyword.other'
-      endCaptures:
-        1: name: 'keyword.other'
-      patterns: [
-          include: '#comments'
-        ,
-          include: '#module_name'
-        ,
-          include: '#module_exports'
-        ,
-          name: 'invalid'
-          match: /[a-z]+/
-      ]
+      include: '#module_import'
     ,
-      name: 'meta.declaration.typeclass'
-      begin: /^\s*\b(class)(?!')\b/
-      end: /\b(where)\b|$/
-      beginCaptures:
-        1: name: 'storage.type.class'
-      endCaptures:
-        1: name: 'keyword.other'
-      patterns: [
-        include: '#type_signature'
-      ]
+      include: '#type_kind_signature'
     ,
-      name: 'meta.declaration.instance'      
-      begin: /^\s*\b(else\s+)?(derive\s+)?(newtype\s+)?(instance)(?!')\b/
-      end: /\b(where)\b|$/
-      contentName: 'meta.type-signature'
-      beginCaptures:
-        1: name: 'keyword.other'
-        2: name: 'keyword.other'
-        3: name: 'keyword.other'
-        4: name: 'keyword.other'
-      endCaptures:
-        1: name: 'keyword.other'
-      patterns: [
-          include: '#type_signature'
-      ]
+      include: '#row_type_declaration'
     ,
-      name: 'meta.foreign.data'
-      begin: /^(\s*)(foreign)\s+(import)\s+(data)\s+({classNameOne})/
-      end: /{indentBlockEnd}/
-      contentName: 'meta.kind-signature'
-      beginCaptures:
-        2: name: 'keyword.other'
-        3: name: 'keyword.other'
-        4: name: 'keyword.other'
-        5: name: 'entity.name.type'
-        6: name: 'keyword.other.double-colon'
-      patterns: [
-          include: '#double_colon'
-        ,
-          include: '#kind_signature'
-      ]
+      include: '#type_synonym_declaration'
     ,
-      name: 'meta.foreign'
-      begin: /^(\s*)(foreign)\s+(import)\s+({functionNameOne})/
-      end: /{indentBlockEnd}/
-      contentName: 'meta.type-signature'
-      beginCaptures:
-        2: name: 'keyword.other'
-        3: name: 'keyword.other'
-        4: name: 'entity.name.function'
-      patterns: [
-          include: '#double_colon'
-        ,
-          include: '#type_signature'
-      ]
+      # data and newtype
+      include: '#data_type_declaration'
     ,
-      name: 'meta.import'
-      begin: /^\s*\b(import)(?!')\b/
-      end: /($|(?=--))/
-      beginCaptures:
-        1: name: 'keyword.other'
-      patterns: [
-          include: '#module_name'
-        ,
-          include: '#module_exports'
-        ,
-          match: /\b(as|hiding)\b/
-          captures:
-            1: name: 'keyword.other'
-      ]
+      include: '#typeclass_declaration'
     ,
-      name: 'meta.declaration.type.data'
-      begin: /{maybeBirdTrack}(\s)*(data|newtype)\s+({typeDecl})\s*(?=\=|$)/
-      end: /{indentBlockEnd}/
-      beginCaptures:
-        2: name: 'storage.type.data'
-        3:
-          name: 'meta.type-signature'
-          patterns: [include: '#type_signature']
-      patterns: [
-          include: '#comments'
-        ,
-          match: /=/
-          captures:
-            0: name: 'keyword.operator.assignment'
-        ,
-          match: /{ctor}/
-          captures:
-            1: patterns: [include: '#data_ctor']
-            2:
-              name: 'meta.type-signature'
-              patterns: [include: '#type_signature']
-        ,
-          match: /\|/
-          captures:
-            0: name: 'punctuation.separator.pipe'
-        ,
-          include: '#record_types'
-      ]
+      include: '#instance_declaration'
     ,
-      name: 'meta.declaration.type.type'
-      begin: /{maybeBirdTrack}(\s)*(type)\s+({typeDecl})\s*(?=\=|$)/
-      end: /{indentBlockEnd}/
-      contentName: 'meta.type-signature'
-      beginCaptures:
-        2: name: 'storage.type.data'
-        3:
-          name: 'meta.type-signature'
-          patterns: [include: '#type_signature']
-      patterns: [
-          match: /=/
-          captures:
-            0: name: 'keyword.operator.assignment'
-        ,
-          include: '#type_signature'
-        ,
-          include: '#record_types'
-        ,
-          include: '#comments'
-      ]
+      include: '#derive_declaration'
     ,
-      name: 'keyword.other'      
-      match: /^\s*\b(derive|where|data|type|newtype|infix[lr]?|foreign(\s+import)?(\s+data)?)(?!')\b/
+      include: '#infix_op_declaration'
     ,
-      name: 'entity.name.function.typed-hole'
-      match: /\?(?:{functionNameOne}|{classNameOne})/
+      include: '#foreign_import_data'
     ,
-      name: 'storage.type'
-      match: /^\s*\b(data|type|newtype)(?!')\b/
-    ,
-      name: 'keyword.control'
-      # match only if a keyword is not followed by:
-      # ' - names with prime symbol
-      #  `:` or `=` -  records define/update
-      match: /\b(do|ado|if|then|else|case|of|let|in)(?!('|\s*(:|=)))\b/
-    ,
-      name: 'constant.numeric.hex.purescript',
-      match: '\\b(?<!\\$)0(x|X)[0-9a-fA-F]+\\b(?!\\$)'
-    ,
-      name: 'constant.numeric.decimal.purescript'
-      match: '''(?x)
-          (?<!\\$)(?:
-            (?:\\b[0-9]+(\\.)[0-9]+[eE][+-]?[0-9]+\\b)| # 1.1E+3
-            (?:\\b[0-9]+[eE][+-]?[0-9]+\\b)|            # 1E+3
-            (?:\\b[0-9]+(\\.)[0-9]+\\b)|                # 1.1
-            (?:\\b[0-9]+\\b(?!\\.))                     # 1
-          )(?!\\$)
-        '''
-      captures:
-        0:
-          name: 'constant.numeric.decimal.purescript'
-        1:
-          name: 'meta.delimiter.decimal.period.purescript'
-        2:
-          name: 'meta.delimiter.decimal.period.purescript'
-        3:
-          name: 'meta.delimiter.decimal.period.purescript'
-        4:
-          name: 'meta.delimiter.decimal.period.purescript'
-        5:
-          name: 'meta.delimiter.decimal.period.purescript'
-        6:
-          name: 'meta.delimiter.decimal.period.purescript'
-    ,
-      name: 'constant.language.boolean'
-      match: /\b(true|false)\b/
-    ,
-      # I think this now just matches when underscores are present
-      name: 'constant.numeric'
-      match: /\b(([0-9]+_?)*[0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\b/
-    ,
-      name: 'string.quoted.triple'
-      begin: /"""/
-      end: /"""/
-      beginCaptures:
-        0: name: 'punctuation.definition.string.begin'
-      endCaptures:
-        0: name: 'punctuation.definition.string.end'
-    ,
-      name: 'string.quoted.double'
-      begin: /"/
-      end: /"/
-      beginCaptures:
-        0: name: 'punctuation.definition.string.begin'
-      endCaptures:
-        0: name: 'punctuation.definition.string.end'
-      patterns: [
-          include: '#characters'
-        ,
-          begin: /\\\s/
-          end: /\\/
-          beginCaptures:
-            0: name: 'markup.other.escape.newline.begin'
-          endCaptures:
-            0: name: 'markup.other.escape.newline.end'
-          patterns: [
-              match: /\S+/
-              name: 'invalid.illegal.character-not-allowed-here'
-          ]
-      ]
-    ,
-      name: 'markup.other.escape.newline'
-      match: /\\$/
-    ,
-      name: 'string.quoted.single'
-      match: /(')({character})(')/
-      captures:
-        1: name: 'punctuation.definition.string.begin'
-        2:
-          patterns:[
-            include: '#characters'
-          ]
-        # {character} macro has 4 capture groups, here 3-6
-        7: name: 'punctuation.definition.string.end'
+      include: '#foreign_import'
     ,
       include: '#function_type_declaration'
     ,
-      # Note recursive regex matching nested parens
-      match: '\\((?<paren>(?:[^()]|\\(\\g<paren>\\))*)(::|∷)(?<paren2>(?:[^()]|\\(\\g<paren2>\\))*)\\)'
-      captures:
-        1: patterns: [include: '$self']
-        2: name: 'keyword.other.double-colon'
-        3: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
+      include: '#typed_hole'
     ,
-      begin: ///
-        ^
-        ( \s* )
-        (?: ( :: | ∷ ) )
-        ///
-      beginCaptures:
-        2: name: 'keyword.other.double-colon'
-      end: ///
-        ^
-        (?! \1 {indentChar}* | {indentChar}* $ )
-        ///
-      patterns: [
-          include: '#type_signature'
-      ]
+      include: '#keywords_orphan'
+    ,
+      include: "#control_keywords"
+    ,
+      include: '#function_infix'
     ,
       include: '#data_ctor'
     ,
-      include: '#comments'
-    ,
       include: '#infix_op'
+    ,
+      include: '#constants_numeric_decimal'
+    ,
+      include: '#constant_numeric'
+    ,
+      include: '#constant_boolean'
+    ,
+      include: '#string_single_quoted'
+    ,
+      include: '#string_double_quoted'
+    ,
+      include: '#string_triple_quoted'
+    ,
+      include: '#markup_newline'
+    ,
+      include: '#double_colon_parens'
+    ,
+      include: '#double_colon_orphan'
+    ,
+      include: '#comments'
     ,
       name: 'keyword.other.arrow'
       match: /\<-|-\>/
@@ -360,6 +150,414 @@ purescriptGrammar =
       match: /,/
   ]
   repository:
+    module_declaration:
+      patterns: [
+        name: 'meta.declaration.module'
+        begin: /^\s*\b(module)(?!')\b/
+        end: /(\bwhere\b)/
+        beginCaptures:
+          1: name: 'keyword.other'
+        endCaptures:
+          1: name: 'keyword.other'
+        patterns: [
+            include: '#comments'
+          ,
+            include: '#module_name'
+          ,
+            include: '#module_exports'
+          ,
+            name: 'invalid'
+            match: /[a-z]+/
+        ]
+      ]
+
+    function_infix:
+      patterns: [
+        name: 'keyword.operator.function.infix'
+        match: /(`){functionName}(`)/
+        captures:
+          1: name: 'punctuation.definition.entity'
+          2: name: 'punctuation.definition.entity'
+        ###
+        In case this regex seems unusual for an infix operator, note
+        that PureScript allows any ordinary function application (elem 4 (1..10))
+        to be rewritten as an infix expression (4 `elem` (1..10)).
+        ###
+      ]
+
+    typeclass_declaration:
+      patterns: [
+        name: 'meta.declaration.typeclass'
+        begin: /^\s*\b(class)(?!')\b/
+        end: /(\bwhere\b|(?=^\S))/
+        beginCaptures:
+          1: name: 'storage.type.class'
+        endCaptures:
+          1: name: 'keyword.other'
+        patterns: [
+          include: '#type_signature'
+
+        ]
+      ]
+
+    instance_declaration:
+      patterns: [
+        name: 'meta.declaration.instance'
+        begin: /^\s*\b(else\s+)?(newtype\s+)?(instance)(?!')\b/
+        end: /(\bwhere\b|(?=^\S))/
+        contentName: 'meta.type-signature'
+        beginCaptures:
+          1: name: 'keyword.other'
+          2: name: 'keyword.other'
+          3: name: 'keyword.other'
+          4: name: 'keyword.other'
+        endCaptures:
+          1: name: 'keyword.other'
+        patterns: [
+            include: '#type_signature'
+        ]
+      ]
+
+    derive_declaration:
+      patterns: [
+        name: 'meta.declaration.derive'
+        begin: /^\s*\b(derive)(\s+newtype)?(\s+instance)?(?!')\b/
+        end: /^(?=\S)/
+        contentName: 'meta.type-signature'
+        beginCaptures:
+          1: name: 'keyword.other'
+          2: name: 'keyword.other'
+          3: name: 'keyword.other'
+          4: name: 'keyword.other'
+        endCaptures:
+          1: name: 'keyword.other'
+        patterns: [
+            include: '#type_signature'
+        ]
+      ]
+
+    foreign_import_data:
+      patterns: [
+        name: 'meta.foreign.data'
+        begin: /^(\s*)(foreign)\s+(import)\s+(data)(?:\s+({classNameOne})\s*({doubleColon}))?/
+        end: /{indentBlockEnd}/
+        contentName: 'meta.kind-signature'
+        beginCaptures:
+          2: name: 'keyword.other'
+          3: name: 'keyword.other'
+          4: name: 'keyword.other'
+          5: name: 'entity.name.type'
+          6: name: 'keyword.other.double-colon'
+        patterns: [
+          include: '#comments'
+          ,
+          include: '#type_signature'
+        ]
+      ]
+
+    foreign_import:
+      patterns: [
+        name: 'meta.foreign'
+        begin: /^(\s*)(foreign)\s+(import)\s+({functionNameOne})/
+        end: /{indentBlockEnd}/
+        contentName: 'meta.type-signature'
+        beginCaptures:
+          2: name: 'keyword.other'
+          3: name: 'keyword.other'
+          4: name: 'entity.name.function'
+        patterns: [
+            include: '#double_colon'
+          ,
+            include: '#type_signature'
+        ]
+      ]
+
+    module_import:
+      patterns: [
+        name: 'meta.import'
+        begin: /^\s*\b(import)(?!')\b/
+        end: /^(?=\S)/
+        beginCaptures:
+          1: name: 'keyword.other'
+        patterns: [
+            include: '#module_name'
+          ,
+            include: '#comments'
+          ,
+            include: '#module_exports'
+          ,
+            match: /\b(as|hiding)\b/
+            captures:
+              1: name: 'keyword.other'
+        ]
+      ]
+
+    type_kind_signature:
+      patterns: [
+        name: 'meta.declaration.type.data.signature'
+        begin: /{maybeBirdTrack}(data|newtype)\s+({classNameOne})\s*({doubleColon})/
+        end: /(?=^\S)/
+        beginCaptures:
+          1: name: 'storage.type.data'
+          2:
+            name: 'meta.type-signature'
+            patterns: [include: '#type_signature']
+          3: name: 'keyword.other.double-colon'
+        patterns: [
+            include: '#comments'
+            include: '#type_signature'
+          ,
+            match: /=/
+            captures:
+              0: name: 'keyword.operator.assignment'
+          ,
+            match: /{ctor}/
+            captures:
+              1: patterns: [include: '#data_ctor']
+              2:
+                name: 'meta.type-signature'
+                patterns: [include: '#type_signature']
+          ,
+            match: /\|/
+            captures:
+              0: name: 'punctuation.separator.pipe'
+          ,
+            include: '#record_types'
+        ]
+      ]
+
+    data_type_declaration:
+      patterns: [
+        name: 'meta.declaration.type.data'
+        begin: /{maybeBirdTrack}(\s)*(data|newtype)\s+({typeDecl})\s*(?=\=|$)/
+        end: /{indentBlockEnd}/
+        beginCaptures:
+          2: name: 'storage.type.data'
+          3:
+            name: 'meta.type-signature'
+            patterns: [include: '#type_signature']
+        patterns: [
+            include: '#comments'
+          ,
+            match: /=/
+            captures:
+              0: name: 'keyword.operator.assignment'
+          ,
+            match: /{ctor}/
+            captures:
+              1: patterns: [include: '#data_ctor']
+              2:
+                name: 'meta.type-signature'
+                patterns: [include: '#type_signature']
+          ,
+            match: /\|/
+            captures:
+              0: name: 'punctuation.separator.pipe'
+          ,
+            include: '#record_types'
+        ]
+      ]
+
+    type_synonym_declaration:
+      patterns: [
+        name: 'meta.declaration.type.type'
+        begin: /{maybeBirdTrack}(\s)*(type)\s+({typeDecl})\s*(?=\=|$)/
+        end: /{indentBlockEnd}/
+        contentName: 'meta.type-signature'
+        beginCaptures:
+          2: name: 'storage.type.data'
+          3:
+            name: 'meta.type-signature'
+            patterns: [include: '#type_signature']
+        patterns: [
+            match: /=/
+            captures:
+              0: name: 'keyword.operator.assignment'
+          ,
+            include: '#type_signature'
+          ,
+            include: '#row_type'
+          ,
+            include: '#record_types'
+          ,
+            include: '#comments'
+        ]
+      ]
+
+    infix_op_declaration:
+      patterns: [
+        name: 'meta.infix.declaration'
+        begin: /^\b(infix[l|r]?)(?!')\b/
+        end: /($)/
+        beginCaptures:
+          1: name: 'keyword.other'
+        patterns: [
+            include: '#comments'
+          ,
+            include: '#type_name'
+          ,
+            name: 'constant.numeric'
+            match: /\d+/
+          ,
+            match: /({operator})/
+            captures:
+              1: name: 'keyword.other'
+          ,
+            match: /\b(as|type)\b/
+            captures:
+              1: name: 'keyword.other'
+        ]
+      ]
+
+    keywords_orphan:
+      patterns: [
+        name: 'keyword.other'
+        match: /^\s*\b(derive|where|data|type|newtype|foreign(\s+import)?(\s+data)?)(?!')\b/
+      ]
+
+    typed_hole:
+      patterns: [
+        name: 'entity.name.function.typed-hole'
+        match: /\?(?:{functionNameOne}|{classNameOne})/
+      ]
+
+    control_keywords:
+      patterns: [
+        name: 'keyword.control'
+        # match only if a keyword is not followed by:
+        # ' - names with prime symbol
+        #  `:` or `=` -  records define/update
+        match: /\b(do|ado|if|then|else|case|of|let|in)(?!('|\s*(:|=)))\b/
+      ]
+
+    constants_numeric_decimal:
+      patterns: [
+        name: 'constant.numeric.decimal.purescript'
+        match: '''(?x)
+            (?<!\\$)(?:
+              (?:\\b[0-9]+(\\.)[0-9]+[eE][+-]?[0-9]+\\b)| # 1.1E+3
+              (?:\\b[0-9]+[eE][+-]?[0-9]+\\b)|            # 1E+3
+              (?:\\b[0-9]+(\\.)[0-9]+\\b)|                # 1.1
+              (?:\\b[0-9]+\\b(?!\\.))                     # 1
+            )(?!\\$)
+          '''
+        captures:
+          0:
+            name: 'constant.numeric.decimal.purescript'
+          1:
+            name: 'meta.delimiter.decimal.period.purescript'
+          2:
+            name: 'meta.delimiter.decimal.period.purescript'
+          3:
+            name: 'meta.delimiter.decimal.period.purescript'
+          4:
+            name: 'meta.delimiter.decimal.period.purescript'
+          5:
+            name: 'meta.delimiter.decimal.period.purescript'
+          6:
+            name: 'meta.delimiter.decimal.period.purescript'
+      ]
+
+    constant_numeric:
+      patterns: [
+        # I think this now just matches when underscores are present
+        name: 'constant.numeric'
+        match: /\b(([0-9]+_?)*[0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\b/
+      ]
+
+    constant_boolean:
+      patterns: [
+        name: 'constant.language.boolean'
+        match: /\b(true|false)(?!')\b/
+      ]
+
+    string_single_quoted:
+      patterns: [
+        name: 'string.quoted.single'
+        match: /(')({character})(')/
+        captures:
+          1: name: 'punctuation.definition.string.begin'
+          2:
+            patterns:[
+              include: '#characters'
+            ]
+          # {character} macro has 4 capture groups, here 3-6
+          7: name: 'punctuation.definition.string.end'
+      ]
+
+    string_double_quoted:
+      patterns: [
+        name: 'string.quoted.double'
+        begin: /"/
+        end: /"/
+        beginCaptures:
+          0: name: 'punctuation.definition.string.begin'
+        endCaptures:
+          0: name: 'punctuation.definition.string.end'
+        patterns: [
+            include: '#characters'
+          ,
+            begin: /\\\s/
+            end: /\\/
+            beginCaptures:
+              0: name: 'markup.other.escape.newline.begin'
+            endCaptures:
+              0: name: 'markup.other.escape.newline.end'
+            patterns: [
+                match: /\S+/
+                name: 'invalid.illegal.character-not-allowed-here'
+            ]
+        ]
+      ]
+
+    string_triple_quoted:
+      patterns: [
+        name: 'string.quoted.triple'
+        begin: /"""/
+        end: /"""/
+        beginCaptures:
+          0: name: 'punctuation.definition.string.begin'
+        endCaptures:
+          0: name: 'punctuation.definition.string.end'
+      ]
+
+    double_colon_parens:
+      patterns: [
+        # Note recursive regex matching nested parens
+        match: '\\((?<paren>(?:[^()]|\\(\\g<paren>\\))*)(::|∷)(?<paren2>(?:[^()]|\\(\\g<paren2>\\))*)\\)'
+        captures:
+          1: patterns: [
+              include: '$self'
+            ]
+          2: name: 'keyword.other.double-colon'
+          3: {name: 'meta.type-signature', patterns: [include: '#type_signature']}
+      ]
+
+    double_colon_orphan:
+      patterns: [
+        begin: ///
+          ^
+          ( \s* )
+          (?: ( :: | ∷ ) )
+          ///
+        beginCaptures:
+          2: name: 'keyword.other.double-colon'
+        end: ///
+          ^
+          (?! \1 {indentChar}* | {indentChar}* $ )
+          ///
+        patterns: [
+            include: '#type_signature'
+        ]
+      ]
+
+    markup_newline:
+      patterns: [
+        name: 'markup.other.escape.newline'
+        match: /\\$/
+      ]
+
+
     block_comment:
       patterns: [
           name: 'comment.block.documentation'
@@ -384,26 +582,7 @@ purescriptGrammar =
               include: '#block_comment'
           ]
       ]
-    record_types:
-      patterns: [
-        name: 'meta.type.record'
-        begin: '\\{'
-        beginCaptures:
-          0:
-            name: 'keyword.operator.type.record.begin.purescript'
-        end: '\\}'
-        endCaptures:
-          0:
-            name: 'keyword.operator.type.record.end.purescript'
-        patterns: [
-            name: 'punctuation.separator.comma.purescript'
-            match: ','
-          ,
-            include: '#record_field_declaration'
-          ,
-            include: '#comments'
-         ]
-    ]
+
     comments:
       patterns: [
           begin: /({maybeBirdTrack}[ \t]+)?(?=--+\s+\|)/
@@ -445,9 +624,11 @@ purescriptGrammar =
         2: name: 'constant.character.escape.octal'
         3: name: 'constant.character.escape.hexadecimal'
         4: name: 'constant.character.escape.control'
+
     infix_op:
       name: 'entity.name.function.infix'
       match: /{operatorFun}/
+
     module_exports:
       name: 'meta.declaration.exports'
       begin: /\(/
@@ -468,9 +649,11 @@ purescriptGrammar =
           name: 'meta.other.constructor-list'
           match: /\(.*?\)/
       ]
+
     module_name:
       name: 'support.other.module'
       match: /(?:{className}\.)*{className}\.?/
+
     function_type_declaration:
       name: 'meta.function.type-declaration'
       begin: ///
@@ -489,24 +672,76 @@ purescriptGrammar =
           include: '#double_colon'
         ,
           include: '#type_signature'
+        ,
+          include: '#record_types'
       ]
+
+    row_type:
+      patterns: [
+        name: 'meta.type.row'
+        begin: /(?<=(^|=)\s*)\(/
+        beginCaptures:
+          0:
+            name: 'keyword.operator.type.row.begin.purescript'
+        end: /\)(?=\s*($|--))/ #  add comment
+        endCaptures:
+          0:
+            name: 'keyword.operator.type.row.end.purescript'
+        patterns: [
+            name: 'punctuation.separator.comma.purescript'
+            match: ','
+          ,
+            include: '#record_field_declaration'
+          ,
+            include: '#comments'
+        ]
+      ]
+
+    record_types:
+      patterns: [
+        name: 'meta.type.record'
+        begin: '\\{'
+        beginCaptures:
+          0:
+            name: 'keyword.operator.type.record.begin.purescript'
+        end: '\\}'
+        endCaptures:
+          0:
+            name: 'keyword.operator.type.record.end.purescript'
+        patterns: [
+            name: 'punctuation.separator.comma.purescript'
+            match: ','
+          ,
+            include: '#record_field_declaration'
+          ,
+            include: '#comments'
+         ]
+      ]
+
     record_field_declaration:
       name: 'meta.record-field.type-declaration'
-      begin: /{functionTypeDeclaration}/
-      end: /(?={functionTypeDeclaration}|})/
+      begin: /{recordFieldDeclaration}/
+      end: /(?={recordFieldDeclaration}|}|\))/
       contentName: 'meta.type-signature'
       beginCaptures:
         1:
           patterns: [
               name: 'entity.other.attribute-name'
               match: /{functionName}/
+            ,
+              name: 'string.quoted.double'
+              match: /"{functionNameOne}|{classNameOne}"/
           ]
         2: name: 'keyword.other.double-colon'
       patterns: [
           include: '#type_signature'
         ,
+          include: '#comments'
+        ,
           include: '#record_types'
       ]
+
+    # this can probalby be removed as we can use type_signature instead
     kind_signature:
       patterns: [
           name: 'keyword.other.star'
@@ -540,10 +775,10 @@ purescriptGrammar =
             4: name: 'keyword.other.big-arrow'
         ,
           name: 'keyword.other.arrow'
-          match: /->|→/
+          match: /(?<!{operatorChar})(->|→)/
         ,
           name: 'keyword.other.big-arrow'
-          match: /=>|⇒/
+          match: /(?<!{operatorChar})(=>|⇒)/
         ,
           name: 'keyword.other.big-arrow-left'
           match: /<=|⇐/
@@ -556,6 +791,9 @@ purescriptGrammar =
           include: '#type_name'
         ,
           include: '#comments'
+        ,
+          name: 'keyword.other'
+          match: /{operator}/
       ]
     type_name:
       name: 'entity.name.type'

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,3 +1,4 @@
+-- start
 {- Test file to visually assess syntax highlighting. -}
 module Main.App where
 module Main.App
@@ -35,6 +36,15 @@ foreign import data R :: { prop :: String }
 
 
 
+-- line comments with no space between first char
+--| some
+
+-- comments with operators after
+--# some
+--! some
+
+
+
 -- Containers
 
 
@@ -45,6 +55,7 @@ data D a = D1 a | D2 (Array a) --comment
 data D1 a
   = D1 a
   | D2 (Array Some.Type)
+  {- comment inside -}
   | D3 (Either Aff.Error Db.Client)
   | D4
     (Array Some.Type) --comment
@@ -72,8 +83,9 @@ newtype MySub vnode msg =
 
 
 -- infix operators
-infixr 0 apply as <| -- comment as <|
-infixl 0 applyFlipped as |>
+-- operators that contain -- within
+infixr 0 apply as :--> -- comment as :-->
+infixl 0 applyFlipped as <--:
 
 
 ---
@@ -109,7 +121,7 @@ class Functor v <= Mountable vnode where
   unmount :: ∀ m. v m -> v m -> T Void E
 
 
---orphan keyword
+--| orphan keyword
 class
 
 
@@ -199,6 +211,7 @@ type QuotedRow a =
   ( "A" :: Int
   -- comment
   , "B" :: { nested :: Number }
+  {- block comment inside -}
   , c :: Either (Maybe Bad) Int
   , d :: Some.Int -- comment
   , e :: Some.Int -- comment
@@ -209,7 +222,7 @@ type QuotedRow a =
 data Rec =
   { module :: String -- comment
   , import :: Either Error (Array String)
-  , import2 :: Either (Maybe Bad) Good -- no proper
+  , import2 :: Either (Maybe Bad) Good
   -- comment
   , data :: String
   , newtype :: String
@@ -330,7 +343,7 @@ foreign import createSource ::
 proxy = Proxy :: Proxy Int -- k is Type
 
 
--- no proper for row
+-- row type
 intAtFoo :: forall r. Variant ( foo :: Int | r )
 intAtFoo = inj (Proxy :: Proxy "foo") 42
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -419,8 +419,13 @@ hex = 0xE0
 
 
 multiString = """
-WOW
+
+ 'text' "WOW" text
+
 """
+
+multiStringOneLine = """ "WOW" text """
+
 
 -- after mult-line string
 class Foo (a :: Symbol)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,42 +5,87 @@ module Main.App
   ) where
 
 
-import Prelude
+import Prelude -- can comment
+import Prelude hiding (div)
 
 import Data.String as String
-import Data.String (Pattern)
-import Data.String (Pattern(..), split)
+-- comment
+import Data.String (Pattern) -- comment
+import Data.String (Pattern(..), split) as String -- comment
+
+
+-- multi-line import
+import Data.String
+  ( Pattern(..), split -- comment
+
+  ) as String -- comment
+import Something (fd)
 
 
 -- Foreign import
 foreign
-foreign import
-foreign import data
-foreign import calculateInterest :: Number -> Number
-foreign import data F :: Type
+foreign import --comment
+foreign import data --comment
+foreign import calculateInterest :: Number -> Number --comment
+foreign import data F :: Type -> Type --comment
+
 
 
 -- Containers
 
 
-data D a = D1 a | D2 String
+data D a = D1 a | D2 String --comment
 
 
-type T = { a :: String }
+type T = { a :: String } --comment
 type T a = { n :: N a, b :: String }
 
 
 newtype N a = N a
 
 
--- infix -- TODO: as
+data Proxy :: forall k. k -> Type
+data Proxy a = Proxy
 
 
-infixr 0 apply as <|
+-- newtype with multi-line kind signature
+newtype MySub ::
+  forall k. (k -> Type) -> k -> Type --comment
+newtype MySub vnode msg =
+  MySub (SubRec vnode msg)
+
+
+-- infix operators
+infixr 0 apply as <| -- comment as <|
 infixl 0 applyFlipped as |>
 
 
--- Type class
+---
+data Sum a b
+  = Inl a
+  | Inr b --comment
+
+
+data Product a b = Product a b
+
+
+-- Type operators
+infixl 6 type Sum as :+: -- comment
+infixl 7 type Product as :*:
+
+
+
+-- type class signatures
+
+
+class Category :: forall k. (k -> k -> Type) -> Constraint
+class Semigroupoid a <= Category a where
+  identity :: forall t. a t t
+
+
+-- type class without where
+class ListToRow :: forall k. RowList k -> Row k -> Constraint
+class ListToRow list row | list -> row
 
 
 class Functor v <= Mountable vnode where
@@ -48,11 +93,46 @@ class Functor v <= Mountable vnode where
   unmount :: ∀ m. v m -> v m -> T Void E
 
 
-derive instance newtypeMySub :: Newtype (MySub vnode msg) _
+--orphan keyword
+class
+
+
+-- multi-line type def
+class Functor v
+  <= Mountable vnode where --comment
+  mount :: ∀ m. Element -> T Void (v m)
+  unmount :: ∀ m. v m -> v m -> T Void E
+
+
+instance
+
+
+instance listToRowCons
+  :: ( ListToRow tail tailRow
+     , Row.Cons label ty tailRow row ) --comment
+  => ListToRow (Cons label ty tail) row
+
+
+--orphan keyword
+derive
+derive instance newtypeMySub :: Newtype (MySub vnode msg) _ --comment
+derive newtype
 derive newtype instance semiringScore :: Semiring Score
 
-derive instance genericCmd :: Generic PhonerCmd _
-instance encodeCmd :: EncodeJson PhonerCmd where
+
+-- multi-line derive
+derive instance genericCmd
+  :: Generic PhonerCmd _
+
+
+-- TODO: multi-line, double-colons
+derive instance genericCmd ::
+  Generic PhonerCmd _
+
+
+-- multi-line instance
+instance encodeCmd
+  :: EncodeJson PhonerCmd where --comment
   encodeJson a = genericEncodeJson a
 
 
@@ -61,7 +141,8 @@ instance functorA :: Functor A where
 
 
 instance functorA :: Functor A where
-   map = split
+   map = split -- comment
+
 
 
 -- chained instances
@@ -75,20 +156,23 @@ instance showString :: MyShow String where
   myShow s = s
 
 
+-- chained instances
 else instance showBoolean :: MyShow Boolean where
-  myShow true = "true"
+  myShow true = "true" --comment
   myShow false = "false"
-else instance showA :: MyShow a where
+else  instance showA :: MyShow a where
   myShow _ = "Invalid"
-
 else newtype instance showA :: MyShow a where
+
+
 
 -- Records with fields that are reserved words
 
 
 type Rec =
-  { module :: String
-  , import :: String
+  { module :: String -- comment
+  , import :: Either Error (Array String)
+  -- comment
   , data :: String
   , newtype :: String
   }
@@ -124,10 +208,10 @@ rec =
 
 updateRec = rec
   { data = "data"
-  , type ="type"
+  , type ="type" -- comment
   , foreign = "foreign"
   , import = "import"
-  , infixl = "infixl"
+  , infixl = "infixl" -- comment
   , infixr = "infixr"
   , infix = "infix"
   , class = "class"
@@ -148,47 +232,93 @@ updateRec = rec
   }
 
 
+type RowLine = ( name :: String, age :: { nested :: Number } )
+
+
 -- quoted row type
-type QuotedRow =
+type QuotedRow a =
   ( "A" :: Int
-  , "B" :: Number
-  )
+  -- comment
+  , "B" :: { nested :: Number }
+  , a :: Int -- comment
+  | a
+  ) --som
 
--- quoted record type
+
+type NotRow a = Either Error (Array Int)
+
+
+-- record with quoted fields
 type Quoted =
-  { "A" :: Int
+  { "A" :: Int -- comment
+  , a :: Boolean
   , "B" :: Number
+  , b :: Int -- comment
+  , "x" :: SmallCap
   }
 
 
--- quoted row type
+-- inlined type def
+quoted ::
+  { "A" :: Int -- comment
+  , a :: Boolean
+  , "B" :: Number
+  , b :: Int -- comment
+  , "x" :: SmallCap
+  }
 quoted =
-  { "A": "a"
-  , "B": 1
+  { "A": "a" -- comment
+  , "B": fn (1 :: Int) x 2 -- typed param in parens
+  , "C": 1 :: Int -- typed param without parens (no proper highlight)
+  , a: 2
   }
+
+
+-- typed hole
+foo :: List Int -> List Int
+foo = map ?myHole
+
 
 
 -- Function, forall
 
 
--- do, where
-toStr :: forall a. a -> Effect Unit
+-- infix functions
+infixFun = 1 `add` 2
+
+
+-- function declaration, do, where
+toStr :: forall a. Functor a => a -> Effect Unit --comment
 toStr x = do
   log $ show num
-  log $ show str
+  log $ show $ 1 `add` 2
   where
-  num = 1
+  -- indented type signature
+  num :: Int
+  num = (something :: Int)
   str = "Str"
+
+
 
 
 addIf true = singleton
 addIf false = const []
 
 
--- let in, case of
-fn
+-- double colon inside quotes breaks proper highlight
+text = (" ::" + global)
+
+
+-- fn type signature without :: in the same line lacks highlighting
+-- it seems to be a bit harder case for proper handling
+-- maybe it's also a sign that it is better not to have it in the code :-)
+ fn
+  -- line orphan signature
   :: forall a. a -> String
+
+
 fn a =
+  -- let in, case of
   let b = "str"
   in case a of
     "1" -> b + "1"
@@ -212,8 +342,25 @@ case' = if true
   else "true"
 
 
---
+-- operators inside type signature ==>
 type Schema
-  = {
-    , widgets :: { id :: Int } ==> Array Widget
+  = { widgets :: { id :: Int } ==> Array Widget --comment
     }
+
+
+
+-- constants
+
+
+int = 1
+
+
+decimal = 41.0
+
+
+hex = 0xE0
+
+
+multiString = """
+WOW
+"""

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -34,7 +34,19 @@ foreign import data F :: Type -> Type --comment
 -- Containers
 
 
-data D a = D1 a | D2 String --comment
+data D a = D1 a | D2 (Array a) --comment
+
+
+-- some issues with proper highlighting inside parens
+data D1 a
+  = D1 a
+  | D2 (Array Some.Type)
+  | D3 (Either Aff.Error Db.Client)
+  | D4
+    (Array Some.Type) --comment
+  | D5 String
+      Int -- not proper
+  | S1 (forall f. f String -> f a)
 
 
 type T = { a :: String } --comment
@@ -249,12 +261,15 @@ type RowRecord a
 type RowRecordLine = Record ( RowLine ( some :: String ) )
 
 
+type EntireRecordCodec = T "Str" ( a :: String , "B" :: Boolean)
+
+
 -- quoted row type
 type QuotedRow a =
   ( "A" :: Int
   -- comment
   , "B" :: { nested :: Number }
-  , a :: Int -- comment
+  , a :: Some.Int -- comment
   | a
   ) --som
 
@@ -283,7 +298,7 @@ quoted ::
 quoted =
   { "A": "a" -- comment
   , "B": fn (1 :: Int) x 2 -- typed param in parens
-  , "C": 1 :: Int -- typed param without parens (no proper highlight)
+  , "C": 1 :: Int -- typed param without parens
   , a: 2
   }
 
@@ -325,7 +340,7 @@ addIf true = singleton
 addIf false = const []
 
 
--- double colon inside quotes breaks proper highlight
+-- double colon inside quoted string
 text = (" ::" + global)
 
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -120,6 +120,10 @@ derive newtype
 derive newtype instance semiringScore :: Semiring Score
 
 
+-- instance without name
+derive newtype instance Semiring Score
+
+
 -- multi-line derive
 derive instance genericCmd
   :: Generic PhonerCmd _
@@ -232,7 +236,17 @@ updateRec = rec
   }
 
 
-type RowLine = ( name :: String, age :: { nested :: Number } )
+-- row type parens are not highlighted as it doesn't seem necessary
+type RowLine a = ( name :: String, age :: { nested :: Number } | a )
+
+
+type RowRecord a
+  = Record
+      ( RowLine ( some :: Either Error (Array a) )
+      )
+
+
+type RowRecordLine = Record ( RowLine ( some :: String ) )
 
 
 -- quoted row type
@@ -274,6 +288,14 @@ quoted =
   }
 
 
+-- proxy
+proxy = Proxy :: Proxy Int -- k is Type
+
+
+intAtFoo :: forall r. Variant (foo :: Int | r)
+intAtFoo = inj (Proxy :: Proxy "foo") 42
+
+
 -- typed hole
 foo :: List Int -> List Int
 foo = map ?myHole
@@ -295,10 +317,8 @@ toStr x = do
   where
   -- indented type signature
   num :: Int
-  num = (something :: Int)
+  num = ((something :: Int) :: Int)
   str = "Str"
-
-
 
 
 addIf true = singleton
@@ -312,11 +332,9 @@ text = (" ::" + global)
 -- fn type signature without :: in the same line lacks highlighting
 -- it seems to be a bit harder case for proper handling
 -- maybe it's also a sign that it is better not to have it in the code :-)
- fn
+fn
   -- line orphan signature
   :: forall a. a -> String
-
-
 fn a =
   -- let in, case of
   let b = "str"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -106,6 +106,9 @@ infixl 6 type Sum as :+: -- comment
 infixl 7 type Product as :*:
 
 
+-- Ctor operators
+infixl 2 Inl as $%
+infixr 2 Inr as %$
 
 -- type class signatures
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,4 +1,6 @@
 -- start
+
+
 {- Test file to visually assess syntax highlighting. -}
 module Main.App where
 module Main.App
@@ -38,6 +40,8 @@ foreign import data R :: { prop :: String }
 
 -- line comments with no space between first char
 --| some
+
+
 
 -- comments with operators after
 --# some
@@ -362,7 +366,7 @@ infixFun = 1 `add` 2
 
 
 -- function declaration, do, where
-toStr :: forall a. Functor a => a -> Effect Unit --comment
+toStr :: forall a. Functor a => { a :: a } -> Effect Unit --comment
 toStr x = do
   log $ show num
   log $ show $ 1 `add` 2
@@ -371,6 +375,16 @@ toStr x = do
   num :: Int
   num = ((something :: Int) :: Int)
   str = "Str"
+
+
+-- double_colon_inlined_signature
+gotConfig :: AVar { a :: Unit } <- AVar.empty
+
+
+SomeType :: ( a :: Int )
+
+
+AVar :: Type → Type
 
 
 addIf true = singleton
@@ -436,6 +450,7 @@ multiString = """
  'text' "WOW" text
 
 """
+
 
 multiStringOneLine = """ "WOW" text """
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -110,6 +110,8 @@ infixl 7 type Product as :*:
 infixl 2 Inl as $%
 infixr 2 Inr as %$
 
+
+
 -- type class signatures
 
 
@@ -139,7 +141,7 @@ class Functor v
   unmount :: ∀ m. v m -> v m -> T Void E
 
 
--- class with type, breaks highlighting
+-- class with row type
 class RowTypeClass (rl :: RL.RowList Type) where
   rowListCodec :: forall proxy. proxy rl -> Record ri -> CA.JPropCodec (Record ro)
 
@@ -187,8 +189,6 @@ instance functorA :: Functor A where
 instance functorA :: Functor A where
    map = split -- comment
 
-
-
 -- chained instances
 
 
@@ -209,7 +209,6 @@ else  instance showA :: MyShow a where
 else newtype instance showA :: MyShow a where
 
 
-
 -- Records with fields that are reserved words
 
 
@@ -217,7 +216,8 @@ else newtype instance showA :: MyShow a where
 type QuotedRow a =
   ( "A" :: Int
   -- comment
-  , "B" :: { nested :: Number }
+  , "B" :: { nested :: Number, nested2 :: { x :: Maybe (Array Int) } | a }
+  , "C" :: { | (c :: Int) }
   {- block comment inside -}
   , c :: Either (Maybe Bad) Int
   , d :: Some.Int -- comment
@@ -290,8 +290,14 @@ updateRec = rec
   }
 
 
--- row type parens are not highlighted as it doesn't seem necessary
-type RowLine a = ( name :: String, age :: { nested :: Number } | a )
+type RowLineSpacing a = ( name :: String, age :: { nested :: Number } | a )
+
+
+--one line row type with no spaces after/before braces
+type RowLine a = (names :: Maybe (Array String), age :: { nested :: Number } | a)
+type RowLine a = { | }
+type RowLine a = { | a }
+type RowLine a = { | (a :: Maybe (Array a)) }
 
 
 type RowRecord a
@@ -331,6 +337,7 @@ quoted =
   { "A": "a" -- comment
   , "B": fn (1 :: Int) x 2 -- typed param in parens
   , "C": 1 :: Int -- typed param without parens
+  , "C": (1 :: Maybe (Array Int) ) x (1 :: Int)
   , a: 2
   }
 
@@ -348,6 +355,14 @@ foreign import createSource ::
 
 -- proxy
 proxy = Proxy :: Proxy Int -- k is Type
+
+
+-- orphan inline signature
+x = 1
+  ::
+    Int
+x = {a: 1} ::
+  { | (a :: Int) }
 
 
 -- row type
@@ -384,13 +399,17 @@ toStr x = do
 gotConfig :: AVar { a :: Unit } <- AVar.empty
 
 
-SomeType :: ( a :: Int )
+-- signatures in ide tooltips
+SomeType :: (a :: Int)
 
 
+-- we may not distinct Type names from type ctors
+-- so we highlight as ctors
 AVar :: Type → Type
 
 
-addIf true = singleton
+--
+-- addIf true = singleton
 addIf false = const []
 
 
@@ -447,6 +466,10 @@ decimal = 41.0
 
 hex = 0xE0
 
+-- quotes after type def
+px = Proxy :: Proxy """fdsfsdf
+  fdsfdsfsdf
+  """
 
 multiString = """
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -30,6 +30,10 @@ foreign import calculateInterest :: Number -> Number --comment
 foreign import data F :: Type -> Type --comment
 
 
+-- import data with record type
+foreign import data R :: { prop :: String }
+
+
 
 -- Containers
 
@@ -37,7 +41,7 @@ foreign import data F :: Type -> Type --comment
 data D a = D1 a | D2 (Array a) --comment
 
 
--- some issues with proper highlighting inside parens
+--
 data D1 a
   = D1 a
   | D2 (Array Some.Type)
@@ -45,7 +49,7 @@ data D1 a
   | D4
     (Array Some.Type) --comment
   | D5 String
-      Int -- not proper
+      Int
   | S1 (forall f. f String -> f a)
 
 
@@ -114,6 +118,11 @@ class Functor v
   <= Mountable vnode where --comment
   mount :: ∀ m. Element -> T Void (v m)
   unmount :: ∀ m. v m -> v m -> T Void E
+
+
+-- class with type, breaks highlighting
+class RowTypeClass (rl :: RL.RowList Type) where
+  rowListCodec :: forall proxy. proxy rl -> Record ri -> CA.JPropCodec (Record ro)
 
 
 instance
@@ -185,9 +194,22 @@ else newtype instance showA :: MyShow a where
 -- Records with fields that are reserved words
 
 
-type Rec =
+-- quoted row type
+type QuotedRow a =
+  ( "A" :: Int
+  -- comment
+  , "B" :: { nested :: Number }
+  , c :: Either (Maybe Bad) Int
+  , d :: Some.Int -- comment
+  , e :: Some.Int -- comment
+  | a
+  ) --som
+
+
+data Rec =
   { module :: String -- comment
   , import :: Either Error (Array String)
+  , import2 :: Either (Maybe Bad) Good -- no proper
   -- comment
   , data :: String
   , newtype :: String
@@ -261,17 +283,7 @@ type RowRecord a
 type RowRecordLine = Record ( RowLine ( some :: String ) )
 
 
-type EntireRecordCodec = T "Str" ( a :: String , "B" :: Boolean)
-
-
--- quoted row type
-type QuotedRow a =
-  ( "A" :: Int
-  -- comment
-  , "B" :: { nested :: Number }
-  , a :: Some.Int -- comment
-  | a
-  ) --som
+type EntireRecordCodec = T "Str" ( a :: String , "B" :: Boolean )
 
 
 type NotRow a = Either Error (Array Int)
@@ -287,7 +299,7 @@ type Quoted =
   }
 
 
--- inlined type def
+-- inlined record type def
 quoted ::
   { "A" :: Int -- comment
   , a :: Boolean
@@ -303,11 +315,23 @@ quoted =
   }
 
 
+-- inlined record type def inside foreign import
+foreign import createSource ::
+  String ->
+  { onOpen :: Effect Unit
+  , onMessage :: SourceEvent -> Effect Unit
+  , onError :: SourceError -> Effect Unit
+  , withCredentials :: Boolean
+  } ->
+  Effect EventSource
+
+
 -- proxy
 proxy = Proxy :: Proxy Int -- k is Type
 
 
-intAtFoo :: forall r. Variant (foo :: Int | r)
+-- no proper for row
+intAtFoo :: forall r. Variant ( foo :: Int | r )
 intAtFoo = inj (Proxy :: Proxy "foo") 42
 
 
@@ -397,3 +421,6 @@ hex = 0xE0
 multiString = """
 WOW
 """
+
+-- after mult-line string
+class Foo (a :: Symbol)


### PR DESCRIPTION
Following [the previous update](https://github.com/purescript-contrib/atom-language-purescript/pull/55). Seems these changes should fix most of the problems _I've seen so far_ with the code highlighting.

This includes quite a lot:

- Multi-line imports support
- Multi-line typeclass defs issues
- Row types
- Record/row string literal fields
- Respecting quoted strings inside type signatures
- etc.

The cases are included in the test `Main.purs` file.

@nwolverson 
I've refactored the rules structure by placing most of them in the repository and then including rules in the patterns by name. Most of the rules inside were not changed though. Hope you are not against such radical refactoring. This actually seems to be a recommended way and this allowed to more easily identify and debug the problems and duplications in the rules. Maybe you will review and make some suggestions.

I propose to try and test these changes for some time, fixing the issues that will be identified along the way. And when it is decided that everything is fine, then I will make some clean-ups so it could be merged.